### PR TITLE
Fix generated assessment workflow stability

### DIFF
--- a/.github/workflows/generated-test-data-assessment.yml
+++ b/.github/workflows/generated-test-data-assessment.yml
@@ -98,10 +98,16 @@ jobs:
       # 6. Upload assessment artifacts
       # -----------------------------------------------------------------------
       - name: Upload assessment artifacts
-        if: always()
+        if: always() && github.actor != 'nektos/act'
         uses: actions/upload-artifact@v4
         with:
           name: assessment-${{ github.run_number }}
           path: artifacts/assessment/
           if-no-files-found: warn
           retention-days: 30
+
+      - name: Report local artifact path (Act)
+        if: always() && github.actor == 'nektos/act'
+        run: |
+          echo "Act run detected; skipping upload-artifact."
+          echo "Assessment artifacts are in: artifacts/assessment/"

--- a/scripts/run-tests-docker.sh
+++ b/scripts/run-tests-docker.sh
@@ -36,6 +36,7 @@ TEST_PATH=""
 ENV_FILE="${PROJECT_ROOT}/.env"
 RESOLVED_ENV_FILE="${PROJECT_ROOT}/.env.resolved"
 RESOLVE_SCRIPT="${PROJECT_ROOT}/scripts/resolve_env.sh"
+JUNIT_XML_PATH="/app/test-results/junit.xml"
 
 
 # Colors for output
@@ -156,6 +157,19 @@ run_pytest_in_runner() {
     return $exit_code
 }
 
+build_junit_xml_path() {
+    local suffix="$1"
+    # Keep filenames deterministic and filesystem-safe across CI runners.
+    local safe_suffix
+    safe_suffix="$(echo "$suffix" | sed -E 's/[^A-Za-z0-9._-]+/-/g' | sed -E 's/^-+|-+$//g')"
+
+    if [ -z "$safe_suffix" ]; then
+        safe_suffix="default"
+    fi
+
+    echo "/app/test-results/junit-${safe_suffix}.xml"
+}
+
 # =============================================================================
 # Parse Arguments
 # =============================================================================
@@ -239,17 +253,22 @@ if [ "$RUN_LIVE_API" = true ]; then
     log_info "Running GitHub AND Azure DevOps tests with LIVE API..."
     log_warning "This will hit real external APIs - may be slow and count against rate limits"
     echo
+
+    JUNIT_XML_PATH="$(build_junit_xml_path "live-api")"
     
     # Run both GitHub and Azure DevOps tests with live_api marker
     TEST_EXIT_CODE=0
-    run_pytest_in_runner "pytest tests/contract/integration/ -v --tb=short --durations=10 -m 'live_api' --junit-xml=/app/test-results/junit-live-api.xml -o junit_family=xunit2 -o junit_logging=all -p no:cacheprovider" || TEST_EXIT_CODE=$?
+    run_pytest_in_runner "pytest tests/contract/integration/ -v --tb=short --durations=10 -m 'live_api' --junit-xml='${JUNIT_XML_PATH}' -o junit_family=xunit2 -o junit_logging=all -p no:cacheprovider" || TEST_EXIT_CODE=$?
 elif [ -n "$TEST_PATH" ]; then
     log_info "Running specific test: $TEST_PATH"
     echo
+
+    junit_suffix="${TEST_PATH//\//-}"
+    JUNIT_XML_PATH="$(build_junit_xml_path "$junit_suffix")"
     
     # Run specific test path
     TEST_EXIT_CODE=0
-    run_pytest_in_runner "pytest '$TEST_PATH' -v --tb=short --junit-xml=/app/test-results/junit.xml -o junit_family=xunit2 -o junit_logging=all -p no:cacheprovider" || TEST_EXIT_CODE=$?
+    run_pytest_in_runner "pytest '$TEST_PATH' -v --tb=short --junit-xml='${JUNIT_XML_PATH}' -o junit_family=xunit2 -o junit_logging=all -p no:cacheprovider" || TEST_EXIT_CODE=$?
 else
     log_info "Running tests in CI-equivalent sequence..."
     log_info "This matches the exact steps from .github/workflows/tests.yml"
@@ -323,14 +342,14 @@ if [ $TEST_EXIT_CODE -eq 0 ]; then
     log_success "All tests passed! 🎉"
     echo
     log_info "Test results available at:"
-    echo "  - JUnit XML: $RESULTS_DIR/junit.xml"
+    echo "  - JUnit XML: $RESULTS_DIR/$(basename "$JUNIT_XML_PATH")"
     echo "  - Coverage:  $RESULTS_DIR/coverage.xml"
     echo
 else
     log_error "Tests failed (exit code: $TEST_EXIT_CODE)"
     echo
     log_info "Test results available at:"
-    echo "  - JUnit XML: $RESULTS_DIR/junit.xml"
+    echo "  - JUnit XML: $RESULTS_DIR/$(basename "$JUNIT_XML_PATH")"
     echo
     log_info "To debug:"
     echo "  1. Check test output above"


### PR DESCRIPTION
## Summary\n- make env loading resilient when .env.resolved exists but is unreadable\n- fallback to .env in pytest setup when .env.resolved cannot be loaded\n- avoid JUnit file collisions by writing per-target XML filenames in Docker test runner\n- make generated assessment workflow compatible with local Act runs by skipping artifact upload only under nektos/act actor\n\n## Validation\n- local Docker parity runs for reporting-views and fixture-scenario tests\n- local gh act workflow run for generated-test-data-assessment.yml\n- GitHub Actions workflow run succeeded on branch: https://github.com/stickleprojects/azure_devops_analyzer/actions/runs/23709256932\n