### PR TITLE
docs: refresh docs and add PR doc validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  docs:
+    name: Documentation Validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate root documentation
+        run: |
+          bash scripts/validate-documentation.sh README.md
+
+      - name: Validate docs tree
+        run: |
+          bash scripts/validate-documentation.sh docs
+
   test:
     name: CI Tests
     runs-on: ubuntu-latest

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,79 @@
 
 ---
 
+## Session: 2026-04-05 - PR Documentation Check Added
+
+### Summary
+
+Added documentation validation as a dedicated GitHub Actions PR check and
+updated the related CI/branch-protection documentation.
+
+### What Was Done
+
+- Added a `Documentation Validation` job to `.github/workflows/tests.yml`
+- Configured the job to validate both `README.md` and the `docs/` tree using
+  `scripts/validate-documentation.sh`
+- Updated `docs/03-operations/github-actions-tests.md` to document the new
+  check name and CI behavior
+- Updated `docs/03-operations/branch-protection-setup.md` to mention the
+  `Documentation Validation` and `CI Tests` check names for PR protection
+
+### Validation
+
+- Ran `bash scripts/validate-documentation.sh docs/03-operations/github-actions-tests.md`
+- Ran `bash scripts/validate-documentation.sh docs/03-operations/branch-protection-setup.md`
+- Ran `bash scripts/run-tests-docker.sh` (`408 passed, 3 skipped, 22 deselected`)
+
+### Current State
+
+- Pull requests now surface documentation validation as a standalone CI check
+- Docker CI parity remains green after the workflow change
+- `branch-protection-setup.md` still has documentation-style warnings due to high
+  code-block density, but no violations
+
+### Next Steps
+
+- If branch protection is configured with explicit check selection in GitHub,
+  ensure both `Documentation Validation` and `CI Tests` are selected
+
+## Session: 2026-04-05 - Documentation Drift Cleanup
+
+### Summary
+
+Cleaned up stale documentation references, aligned session guidance with the
+repository's Docker-first workflow, and refreshed dashboard/status pages to
+match the current workspace contents.
+
+### What Was Done
+
+- Updated `README.md` quickstart instructions to reference the existing
+  `Start-RepoAnalysis.sh` helper and resolved-env Docker workflow
+- Refreshed `docs/README.md` navigation to include the current operations and
+  implementation documents, and removed links to missing files
+- Updated `docs/01-strategy/requirements-status.md` to reflect the current
+  9-dashboard set and mark the dedicated Security Dashboard requirement complete
+- Reworked `docs/03-operations/session-continuity.md` to point at live source-of-truth
+  docs and use Docker/MCP verification commands instead of stale local Python steps
+- Fixed broken "next steps" links in architecture and visualization docs
+- Expanded `docs/04-implementation/README.md` so it reflects the actual planning
+  documents present in the directory
+
+### Validation
+
+- Ran `bash scripts/validate-documentation.sh README.md` (0 violations, 0 warnings)
+- Ran `bash scripts/validate-documentation.sh docs` (0 violations, 20 warnings)
+
+### Current State
+
+- Core documentation entry points now reference files that exist in the workspace
+- Session guidance matches the repo's Docker-first execution model
+- Dashboard status documentation matches the current Grafana dashboard inventory
+- Documentation validator passes with no violations; remaining warnings are concentrated in older, code-heavy planning and operations docs
+
+### Next Steps
+
+- Triage the remaining documentation warnings in legacy, code-heavy planning and operations docs
+
 ## Session: 2026-04-05 - Documentation Maintenance and Validator Fix
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ This system analyzes repositories from multiple platforms (Azure DevOps and GitH
 
 Use the helper to bootstrap the Docker stack, create `.env`, initialize the schema, and start extraction:
 
-- PowerShell (Windows/macOS/Linux): `pwsh ./Start-RepoAnalysis.ps1 -RegenerateEnv`
-- Bash (macOS/Linux/Git Bash): `./Start-RepoAnalysis.sh --regenerate-env`
+- Bash (macOS/Linux/Git Bash on Windows): `./Start-RepoAnalysis.sh --regenerate-env`
 
 What happens:
 
@@ -34,8 +33,9 @@ What happens:
 To start analysis manually without the helper:
 
 1. Copy and edit `.env` from `.env.example`
-2. Start services: `docker compose up -d`
-3. Submit a run: `docker compose run --rm scheduler python /app/scripts/submit_extraction_task.py`
+2. Resolve environment variable references: `bash ./scripts/resolve_env.sh > .env.resolved`
+3. Start services: `docker compose --env-file .env.resolved up -d`
+4. Submit a run: `docker compose --env-file .env.resolved run --rm scheduler python /app/scripts/submit_extraction_task.py`
 
 How to know it is running:
 
@@ -44,7 +44,7 @@ How to know it is running:
 - Flower UI at `http://localhost:5555`
 - Grafana dashboards at `http://localhost:3000` (admin/admin)
 
-See [Start-RepoAnalysis.ps1](Start-RepoAnalysis.ps1#L1-L50) for parameters and examples.
+See [Start-RepoAnalysis.sh](Start-RepoAnalysis.sh#L1-L50) for parameters and examples.
 
 ## Documentation Structure
 
@@ -95,10 +95,11 @@ Start with [docs/README.md](docs/README.md) for role-based navigation, then revi
 
 ## Requirements
 
+- Docker with Compose V2
+- Bash 4.0+ for `Start-RepoAnalysis.sh`
 - Azure DevOps organization access
 - Personal Access Token (PAT) with appropriate permissions
 - PostgreSQL 15+ with TimescaleDB
-- Python 3.11+
 - Grafana 10+
 - RabbitMQ 3.12+
 
@@ -141,11 +142,13 @@ See [scripts/README.md](scripts/README.md) for full reference and step-by-step d
 azure-devops-analyzer/
 ├── docs/                    # This documentation
 ├── src/
-│   ├── extractors/         # Azure DevOps data extraction
-│   ├── analyzers/          # Code analysis modules
-│   ├── storage/            # Database models and operations
-│   ├── scheduler/          # Job scheduling and tasks
-│   └── utils/              # Shared utilities
+│   ├── analyzers/          # Platform-agnostic analysis modules
+│   ├── api/                # API-facing entry points and integration surfaces
+│   ├── config/             # Runtime configuration
+│   ├── database/           # Database models and storage layer
+│   ├── extractors/         # GitHub and Azure DevOps data extraction
+│   ├── scheduler/          # Job scheduling and task submission
+│   └── workflows/          # Orchestration across extractors and analyzers
 ├── dashboards/             # Grafana dashboard definitions
 ├── database/               # Database schema and migrations
 ├── tests/                  # Unit and integration tests

--- a/docs/01-strategy/requirements-status.md
+++ b/docs/01-strategy/requirements-status.md
@@ -65,7 +65,7 @@
 
 | Category                    | Complete | Partial | Not Started | Total |
 | --------------------------- | -------- | ------- | ----------- | ----- |
-| Functional Requirements     | 45       | 10      | 17          | 72    |
+| Functional Requirements     | 46       | 9       | 17          | 72    |
 | Non-Functional Requirements | 9        | 6       | 4           | 19    |
 
 **Note:** FR-13.2, FR-13.3, FR-13.5 (formerly FR-11.2, FR-11.3, FR-11.5) updated to Complete - Team management data layer fully implemented with 11 passing integration tests (2026-01-29).
@@ -220,14 +220,14 @@
 
 ### FR-11: Visualization and Reporting
 
-| ID      | Requirement                                             | Priority | Status                         | Notes                                                                                                                                                        |
-| ------- | ------------------------------------------------------- | -------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| FR-11.1 | System shall provide Grafana dashboards for all metrics | High     | :white_check_mark: Complete    | 7 dashboards implemented: Team Overview, Repository Overview, Repository Deep-Dive, Pull Requests, Contributor Analytics, Security Dashboard, Dashboard Home |
-| FR-11.2 | System shall support time-range filtering               | High     | :white_check_mark: Complete    | All dashboards use Grafana time picker; navigation preserves time range                                                                                      |
-| FR-11.3 | System shall support drill-down navigation              | Medium   | :white_check_mark: Complete    | Repository names in tables link to Deep-Dive dashboard; cross-dashboard navigation links on all dashboards                                                   |
-| FR-11.4 | System shall provide security-focused dashboard views   | High     | :large_orange_diamond: Partial | Security metrics included in Team Overview and Repository Deep-Dive (vulnerabilities, EOL deps); dedicated Security dashboard not yet created                |
+| ID      | Requirement                                             | Priority | Status                      | Notes                                                                                                                                                                                           |
+| ------- | ------------------------------------------------------- | -------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR-11.1 | System shall provide Grafana dashboards for all metrics | High     | :white_check_mark: Complete | 9 dashboards implemented: Admin Dashboard, Team Overview, Repository Overview, Repository Deep-Dive, Service Overview, Pull Requests, Contributor Analytics, Security Dashboard, Dashboard Home |
+| FR-11.2 | System shall support time-range filtering               | High     | :white_check_mark: Complete | All dashboards use Grafana time picker; navigation preserves time range                                                                                                                         |
+| FR-11.3 | System shall support drill-down navigation              | Medium   | :white_check_mark: Complete | Repository names in tables link to Deep-Dive dashboard; cross-dashboard navigation links on all dashboards                                                                                      |
+| FR-11.4 | System shall provide security-focused dashboard views   | High     | :white_check_mark: Complete | Dedicated Security Dashboard implemented in `dashboards/security-dashboard.json`; security metrics are also surfaced in Team Overview and Repository Deep-Dive                                  |
 
-**FR-11 Summary:** 3/4 Complete, 1/4 Partial, 0/4 Not Started
+**FR-11 Summary:** 4/4 Complete, 0/4 Partial, 0/4 Not Started
 
 ---
 

--- a/docs/02-architecture/data-storage.md
+++ b/docs/02-architecture/data-storage.md
@@ -442,5 +442,5 @@ PostgreSQL is configured with WAL archiving (`wal_level = replica`, `archive_mod
 
 ## Next Steps
 
-- See [05-orchestration.md](05-orchestration.md) for data insertion workflows
-- Review [06-visualization.md](06-visualization.md) for querying this data in Grafana
+- See [job-orchestration.md](job-orchestration.md) for data insertion workflows
+- Review [../03-operations/visualization.md](../03-operations/visualization.md) for querying this data in Grafana

--- a/docs/02-architecture/job-orchestration.md
+++ b/docs/02-architecture/job-orchestration.md
@@ -95,5 +95,5 @@ Flower provides a web-based UI for monitoring Celery clusters.
 
 ## Next Steps
 
-- See [06-visualization.md](06-visualization.md) for Grafana dashboard setup
-- Review [07-implementation-plan.md](07-implementation-plan.md) for deployment timeline
+- See [../03-operations/visualization.md](../03-operations/visualization.md) for Grafana dashboard setup
+- Review [../04-implementation/README.md](../04-implementation/README.md) for current planning and rollout work

--- a/docs/02-architecture/system-architecture.md
+++ b/docs/02-architecture/system-architecture.md
@@ -50,14 +50,16 @@ azure-devops-analyzer/
 ├── Dockerfile
 └── requirements.txt
 ```
-│   └── utils/
-│       ├── __init__.py
-│       ├── job_tracker.py       # Job status tracking
-│       └── notifications.py     # Alert notifications
+
+│ └── utils/
+│ ├── **init**.py
+│ ├── job_tracker.py # Job status tracking
+│ └── notifications.py # Alert notifications
 ├── workers/
-│   └── worker_start.sh          # Worker startup script
+│ └── worker_start.sh # Worker startup script
 └── config/
-    └── scheduler.yaml           # Scheduler configuration
+└── scheduler.yaml # Scheduler configuration
+
 ```
 
 ## Core Components
@@ -151,5 +153,6 @@ Robust error handling ensures that failures in one repository or analysis step d
 
 ## Next Steps
 
-- See [06-visualization.md](06-visualization.md) for Grafana dashboard setup
-- Review [07-implementation-plan.md](07-implementation-plan.md) for deployment timeline
+- See [../03-operations/visualization.md](../03-operations/visualization.md) for Grafana dashboard setup
+- Review [../04-implementation/README.md](../04-implementation/README.md) for current planning and rollout work
+```

--- a/docs/02-architecture/technology-stack.md
+++ b/docs/02-architecture/technology-stack.md
@@ -488,5 +488,5 @@ This document provides a comprehensive overview of all technologies, tools, and 
 
 ## Next Steps
 
-- Review [01-architecture.md](01-architecture.md) for architecture overview
-- See [07-implementation-plan.md](07-implementation-plan.md) for deployment schedule
+- Review [system-architecture.md](system-architecture.md) for the architecture overview
+- See [../04-implementation/README.md](../04-implementation/README.md) for current implementation planning

--- a/docs/03-operations/branch-protection-setup.md
+++ b/docs/03-operations/branch-protection-setup.md
@@ -9,21 +9,25 @@ This guide explains how to protect the main branch to ensure all merges go throu
 When branch protection is enabled on `main`:
 
 ✅ **All PRs require**:
+
 - At least 1 approval before merge
 - Stale reviews are dismissed when new commits are pushed
 - Status checks must pass
 
 ✅ **Prevented actions**:
+
 - Force pushes to main (even admins)
 - Direct deletion of main branch
 - Merging without approvals
 
 ✅ **Enforced for**:
+
 - All users (including repository administrators)
 
 ## Quick Setup (Using GitHub CLI)
 
 ### Prerequisites
+
 1. **GitHub CLI installed**: https://cli.github.com
 2. **Authenticated with GitHub**:
    ```bash
@@ -39,6 +43,7 @@ bash scripts/setup-branch-protection.sh
 ```
 
 **Output** (example):
+
 ```
 ✅ Branch protection rules applied:
    • Require pull request reviews (1 approval minimum)
@@ -62,6 +67,7 @@ If you prefer to set this up manually:
    - ✅ **Dismiss stale pull request approvals when new commits are pushed**
    - ✅ **Require approval of reviews before merging** (1 required)
    - ✅ **Require status checks to pass before merging**
+   - If GitHub asks you to choose checks explicitly, select `Documentation Validation` and `CI Tests`
    - ✅ **Include administrators** (enforce for all users)
 5. Disable these:
    - ☐ Allow force pushes
@@ -84,7 +90,7 @@ gh api repos/stickleprojects/azure_devops_analyzer/branches/main/protection
 
 - **PR Requirements**: See [feature-development-workflow.md](../docs/03-operations/feature-development-workflow.md)
 - **Code Review Standards**: See [05-code-review.md](../agents/05-code-review.md)
-- **Pre-Commit Validation**: See [.ai/instructions.md](../.ai/instructions.md#pre-commit-validation-gates)
+- **Pre-Commit Validation**: See [.ai/operations.md](../.ai/operations.md#pre-commit-validation-gates)
 - **Session Continuity**: See [session-continuity.md](../docs/03-operations/session-continuity.md)
 
 ## Updating Protection Rules
@@ -117,9 +123,9 @@ A: Reviewers need to re-review after new commits are pushed. This ensures review
 A: No - branch protection applies equally to all users.
 
 **Q: Do I need status checks configured?**  
-A: The script doesn't require them, but they can be added. Any CI/CD workflows will automatically be required.
+A: Yes. For this repository, PRs should require both `Documentation Validation` and `CI Tests` when specific checks are selected in GitHub branch protection.
 
 ---
 
-**Last Updated**: 2026-01-29  
+**Last Updated**: 2026-04-05  
 **Status**: ✅ Branch protection active

--- a/docs/03-operations/deployment-plan.md
+++ b/docs/03-operations/deployment-plan.md
@@ -7,7 +7,7 @@ This phased implementation plan breaks down the Azure DevOps Repository Analysis
 ## Timeline Summary
 
 **Phase 1**: Foundation (Weeks 1-2) ✅ **COMPLETED**
-**Phase 2**: Core Analysis (Weeks 3-5) 🔄 **IN PROGRESS** 
+**Phase 2**: Core Analysis (Weeks 3-5) 🔄 **IN PROGRESS**
 **Phase 3**: Metrics Collection (Weeks 6-7) 🔄 **IN PROGRESS**
 **Phase 4**: Orchestration (Week 8) ❌ **NOT STARTED**
 **Phase 5**: Visualization (Weeks 9-10) ✅ **COMPLETED**
@@ -521,8 +521,8 @@ azure-devops-analyzer/
 
 ### Technology Stack Reference
 
-See [08-technology-stack.md](08-technology-stack.md) for complete technology details.
+See [../02-architecture/technology-stack.md](../02-architecture/technology-stack.md) for complete technology details.
 
 ### Architecture Reference
 
-See [01-architecture.md](01-architecture.md) for system architecture details.
+See [../02-architecture/system-architecture.md](../02-architecture/system-architecture.md) for system architecture details.

--- a/docs/03-operations/github-actions-tests.md
+++ b/docs/03-operations/github-actions-tests.md
@@ -8,7 +8,7 @@ Automated test execution on every push and pull request using GitHub Actions. Te
 
 ### Triggers
 
-- **Push**: All branches including main, develop, and feature branches (feat/\*\*)
+- **Push**: `main` and `develop`
 - **Pull Request**: main and develop branches
 - **Manual**: Can be triggered via GitHub Actions UI
 
@@ -21,25 +21,32 @@ Automated test execution on every push and pull request using GitHub Actions. Te
 
 ## Test Execution
 
-### Step 1: Setup
+### Step 1: Documentation Validation
+
+- Runs `bash scripts/validate-documentation.sh README.md`
+- Runs `bash scripts/validate-documentation.sh docs`
+- Executes as a dedicated PR status check: **Documentation Validation**
+- Fails the workflow only on documentation violations; warnings are reported but do not fail the job
+
+### Step 2: Setup
 
 - Checks out code
 - Sets up Python 3.12 with pip caching
 - Installs all dependencies from requirements.txt
 
-### Step 2: Configuration
+### Step 3: Configuration
 
 - Creates `.env.test` with database connection details
 - PostgreSQL automatically available via service container
 - No need for Docker Compose locally in CI
 
-### Step 3: Database Migrations
+### Step 4: Database Migrations
 
 - Runs migrations to set up schema
 - Creates tables, indexes, and hypertables
 - Safe to run multiple times (idempotent)
 
-### Step 4: Tests
+### Step 5: Tests
 
 **Unit Tests** (`tests/unit/`):
 
@@ -54,7 +61,7 @@ Automated test execution on every push and pull request using GitHub Actions. Te
 - May include external API calls (with mocks where possible)
 - ~15-25 seconds typically
 
-### Step 5: Coverage & Reports
+### Step 6: Coverage & Reports
 
 - Generates coverage report (lines/branches covered)
 - Reports to Codecov if token available
@@ -66,12 +73,14 @@ Automated test execution on every push and pull request using GitHub Actions. Te
 
 ✅ **PR can merge only if**:
 
+- Documentation validation completes without violations
 - All unit tests pass
 - All integration tests pass
 - Build completes without errors
 
 ❌ **PR cannot merge if**:
 
+- Documentation validation finds violations
 - Any test fails
 - Workflow times out (> 30 min)
 - Environment setup fails
@@ -80,7 +89,9 @@ Automated test execution on every push and pull request using GitHub Actions. Te
 
 1. Go to your PR on GitHub
 2. Scroll to "Checks" section
-3. Click "Tests" workflow
+3. Click the relevant check:
+   - `Documentation Validation` for docs validation output
+   - `CI Tests` for unit/integration/coverage output
 4. See detailed output, logs, and failures
 
 ## GitHub Actions Capabilities vs Requirements
@@ -172,6 +183,11 @@ PostgreSQL service has automatic health checks:
 6. **Scheduled Runs**: Nightly full test suite
 7. **Artifact Storage**: Store test reports/logs
 
+## Current Check Names
+
+- `Documentation Validation` — validates `README.md` and the `docs/` tree
+- `CI Tests` — runs the Python and shell test paths based on changed files
+
 ## Related Documentation
 
 - [Testing Strategy](../../agents/04-testing.md)
@@ -181,5 +197,5 @@ PostgreSQL service has automatic health checks:
 
 ---
 
-**Last Updated**: 2026-01-29
-**Status**: ✅ Active - Tests required for all PRs
+**Last Updated**: 2026-04-05
+**Status**: ✅ Active - documentation validation and tests run on PRs

--- a/docs/03-operations/session-continuity.md
+++ b/docs/03-operations/session-continuity.md
@@ -109,7 +109,7 @@ When starting a new AI session, provide the AI with this information:
 
 ### 1. Current Project Status
 
-- [ ] **Phase**: Which implementation phase are we in? (see [07-implementation-plan.md](07-implementation-plan.md))
+- [ ] **Focus area**: Which active workstream are we in? (see [../04-implementation/README.md](../04-implementation/README.md) and [../01-strategy/requirements-status.md](../01-strategy/requirements-status.md))
 - [ ] **Last completed task**: What was the last thing completed?
 - [ ] **In-progress work**: What was being worked on when the session ended?
 - [ ] **Blockers**: Any issues or decisions pending?
@@ -134,50 +134,21 @@ When starting a new AI session, provide the AI with this information:
 
 ### Current State
 
-| Field                 | Value                                       |
-| --------------------- | ------------------------------------------- |
-| **Current Phase**     | Phase 1: Foundation                         |
-| **Current Week**      | Week 1                                      |
-| **Last Session Date** | _[Update after each session]_               |
-| **Session Focus**     | _[Brief description of what was worked on]_ |
+| Field                 | Value                                    |
+| --------------------- | ---------------------------------------- |
+| **Current Focus**     | _[Update after each session]_            |
+| **Current Branch**    | _[Update after each session]_            |
+| **Last Session Date** | _[Update after each session]_            |
+| **Source of Truth**   | `PROGRESS.md` + `requirements-status.md` |
 
 ### Implementation Progress
 
-#### Phase 1: Foundation (Weeks 1-2)
+Track current work in the living project records instead of maintaining a second,
+stale phase plan in this file:
 
-**Week 1: Environment Setup**
-
-- [ ] Set up development environment
-- [ ] Configure Azure DevOps access
-- [ ] Initialize version control (DONE - repo initialized)
-
-**Week 2: Database Setup**
-
-- [ ] Install PostgreSQL 15 and TimescaleDB
-- [ ] Design and create database schema
-- [ ] Create database migrations
-- [ ] Implement basic data access layer
-- [ ] Write unit tests for database operations
-
-#### Phase 2: Core Analysis (Weeks 3-5)
-
-_Not started_
-
-#### Phase 3: Metrics Collection (Weeks 6-7)
-
-_Not started_
-
-#### Phase 4: Orchestration (Week 8)
-
-_Not started_
-
-#### Phase 5: Visualization (Weeks 9-10)
-
-_Not started_
-
-#### Phase 6: Production Hardening (Weeks 11-12)
-
-_Not started_
+- `PROGRESS.md` for session-by-session summaries and next steps
+- `docs/01-strategy/requirements-status.md` for requirement-level status
+- `docs/04-implementation/README.md` for active planning and future work
 
 ---
 
@@ -228,7 +199,8 @@ Use this template at the end of each session:
 ```bash
 # Any setup or verification commands for next session
 git status
-pip install -r requirements.txt
+bash scripts/check_mcp_health.sh
+bash scripts/run-tests-docker.sh
 ```
 ````
 
@@ -257,17 +229,14 @@ ls -la src/
 ### Verify Environment
 
 ```bash
-# Check Python version
-python --version
+# Verify workspace automation and local MCP tooling
+bash scripts/check_mcp_health.sh
 
-# Verify dependencies
-pip list
+# Run the Docker-based test suite
+bash scripts/run-tests-docker.sh
 
-# Run tests
-pytest
-
-# Check database connection
-python -c "from src.database import engine; print('DB OK')"
+# Inspect running services when debugging the stack
+docker compose ps
 ```
 
 ---
@@ -276,13 +245,13 @@ python -c "from src.database import engine; print('DB OK')"
 
 When resuming, these files provide essential context:
 
-| File                                                   | Purpose                            |
-| ------------------------------------------------------ | ---------------------------------- |
-| [00-quick-reference.md](00-quick-reference.md)         | System overview and quick commands |
-| [07-implementation-plan.md](07-implementation-plan.md) | Full task breakdown by phase       |
-| [10-requirements.md](10-requirements.md)               | Dependencies and environment setup |
-| [docker-compose.yml](../docker-compose.yml)            | Service configuration              |
-| [requirements.txt](../requirements.txt)                | Python dependencies                |
+| File                                                                           | Purpose                            |
+| ------------------------------------------------------------------------------ | ---------------------------------- |
+| [../../PROGRESS.md](../../PROGRESS.md)                                         | Session summaries and next actions |
+| [../01-strategy/requirements-status.md](../01-strategy/requirements-status.md) | Requirement status and backlog     |
+| [../04-implementation/README.md](../04-implementation/README.md)               | Active planning documents          |
+| [docker-setup.md](docker-setup.md)                                             | Environment and service setup      |
+| [../../scripts/README.md](../../scripts/README.md)                             | Script entry points and commands   |
 
 ---
 
@@ -327,7 +296,7 @@ Track session history here for reference:
 ### At Session Start
 
 1. Share the current project status (use checklist above)
-2. Reference this document: "See docs/11-session-continuity.md"
+2. Reference this document: "See docs/03-operations/session-continuity.md"
 3. State the specific goal for the session
 4. Mention any blockers or decisions needed
 

--- a/docs/03-operations/visualization.md
+++ b/docs/03-operations/visualization.md
@@ -18,6 +18,7 @@ All dashboards are stored in `dashboards/` and auto-provisioned by Grafana on st
 **Purpose**: High-level team metrics aggregated across all repositories
 
 **Sections**:
+
 - **Team Summary**: 6 stat panels (repositories, active contributors, commits, PRs created/merged, open PRs)
 - **Team Activity Trends**: Commit activity, PR throughput, daily active contributors, lines changed
 - **Repository Health Matrix**: Color-coded table showing all repos with commits, contributors, open PRs, vulnerabilities, stale branches - click to drill down
@@ -31,6 +32,7 @@ All dashboards are stored in `dashboards/` and auto-provisioned by Grafana on st
 **Purpose**: List and compare all repositories
 
 **Panels**:
+
 - **Total Repositories**: Count of active repositories
 - **Total Commits/PRs/Contributors**: Aggregate stats
 - **Commit Activity**: Time series of commits per day (30 days)
@@ -45,6 +47,7 @@ All dashboards are stored in `dashboards/` and auto-provisioned by Grafana on st
 **Template Variable**: Repository selector dropdown
 
 **Sections**:
+
 - **Header & Summary**: Repository name, total commits, PRs, contributors
 - **Quick Health Indicators**: Active contributors, test coverage, vulnerabilities, open PRs, stale branches, tech debt
 - **Development Activity**: Commit activity, lines changed, top contributors, top reviewers
@@ -61,6 +64,7 @@ All dashboards are stored in `dashboards/` and auto-provisioned by Grafana on st
 **Purpose**: Track PR quality and review efficiency across all repos
 
 **Panels**:
+
 - **Open/Merged/Closed PRs**: Stat panels with 30-day counts
 - **Avg PR Size**: Lines changed per PR
 - **PR Status Distribution**: Pie chart (open/merged/closed)
@@ -74,6 +78,7 @@ All dashboards are stored in `dashboards/` and auto-provisioned by Grafana on st
 **Purpose**: Organization-wide security overview with vulnerability and end-of-life dependency tracking
 
 **Sections**:
+
 - **Organization Security Summary**: Total vulnerabilities, EOL dependencies, repositories affected
 - **Vulnerability Analysis**: Severity distribution pie chart, top repositories by critical vulnerabilities
 - **End-of-Life Dependencies**: EOL status categorization (expired, expiring soon, future), repository security overview table with drilldown links
@@ -83,6 +88,7 @@ All dashboards are stored in `dashboards/` and auto-provisioned by Grafana on st
 ## Dashboard Navigation
 
 All dashboards are cross-linked:
+
 - **Header Links**: Each dashboard has navigation links to all other dashboards
 - **Data Links**: Repository names in tables are clickable and navigate to the Deep-Dive dashboard with that repository pre-selected
 - **Time Preservation**: Navigation links preserve the current time range (`keepTime: true`)
@@ -99,7 +105,7 @@ All dashboards are cross-linked:
 - **EOL Dependencies**: List of packages that have reached End-of-Life
 - **Vulnerability Trends**: Time series showing vulnerability counts over time
 
-*Note: Security features are currently implemented within the Repository Deep-Dive dashboard under the 'Security & Dependencies' section.*
+_Note: Security features are currently implemented within the Repository Deep-Dive dashboard under the 'Security & Dependencies' section._
 
 ### Code Quality Dashboard (Not Yet Implemented)
 
@@ -167,5 +173,5 @@ Grafana is configured to use connection pooling to manage database load efficien
 
 ## Next Steps
 
-- See [07-implementation-plan.md](07-implementation-plan.md) for deployment roadmap
-- Review [08-technology-stack.md](08-technology-stack.md) for complete technology overview
+- See [../04-implementation/README.md](../04-implementation/README.md) for current planning documents
+- Review [../02-architecture/technology-stack.md](../02-architecture/technology-stack.md) for the complete technology overview

--- a/docs/04-implementation/README.md
+++ b/docs/04-implementation/README.md
@@ -6,20 +6,31 @@ This folder contains planning documents for future initiatives, architectural de
 
 ## Contents
 
+- **[caching-strategy.md](caching-strategy.md)** — Current caching architecture, tradeoffs, and guardrails
+- **[extractor-caching-plan.md](extractor-caching-plan.md)** — Extractor cache rollout plan and repository impact
+- **[file-cache-plan.md](file-cache-plan.md)** — File-based cache implementation details
+- **[generated-test-data-assessment.md](generated-test-data-assessment.md)** — Assessment of generated fixture data and follow-up actions
+- **[github-private-repo-access.md](github-private-repo-access.md)** — Private repository authentication approach
+- **[contributor-team-allocation-strategy.md](contributor-team-allocation-strategy.md)** — Team assignment architecture
+- **[integration-testing-priority-assessment.md](integration-testing-priority-assessment.md)** — Testing strategy and priorities
 - **[parallelization-plan.md](parallelization-plan.md)** — Multi-worker repository processing strategy, rate limiting, scaling from 1 to 10+ workers
 - **[infrastructure-options.md](infrastructure-options.md)** — Kubernetes vs Docker Compose evaluation, pros/cons, migration strategy
 
 ## Quick Links
 
-| Document                  | Focus                       | Status                |
-| ------------------------- | --------------------------- | --------------------- |
-| parallelization-plan.md   | Scaling to 5-10 workers     | Active planning phase |
-| infrastructure-options.md | Infrastructure architecture | High-level evaluation |
+| Document                                   | Focus                        | Status                |
+| ------------------------------------------ | ---------------------------- | --------------------- |
+| caching-strategy.md                        | Current cache design         | Implemented           |
+| integration-testing-priority-assessment.md | Test strategy and sequencing | Reference             |
+| contributor-team-allocation-strategy.md    | Team mapping architecture    | Implemented           |
+| parallelization-plan.md                    | Scaling to 5-10 workers      | Active planning phase |
+| infrastructure-options.md                  | Infrastructure architecture  | High-level evaluation |
 
 ## Recommended Reading Order
 
 1. **[parallelization-plan.md](parallelization-plan.md)** — Understand the multi-worker strategy, rate limiting approach, and migration path
 2. **[infrastructure-options.md](infrastructure-options.md)** — Evaluate Kubernetes vs Docker Compose, understand tradeoffs
+3. **[integration-testing-priority-assessment.md](integration-testing-priority-assessment.md)** — Review the testing backlog and validation priorities
 
 ## Key Topics
 
@@ -36,6 +47,16 @@ This folder contains planning documents for future initiatives, architectural de
 - **Kubernetes** (Future): Better scalability, auto-healing, rolling updates
 - **Hybrid Approach**: Docker Compose for development/testing, Kubernetes for production
 
+## Architecture Guardian
+
+Implementation plans in this folder still have to respect the core system
+boundaries:
+
+- Extractors stay focused on platform-specific data collection
+- Analyzers stay platform-agnostic and return data structures, not writes
+- Database writes flow through the database layer rather than ad hoc callers
+- Workflows coordinate components instead of absorbing business logic
+
 ---
 
 ## Current Implementation Guides
@@ -45,11 +66,13 @@ This folder contains planning documents for future initiatives, architectural de
 - ✅ **File-based caching** - [file-cache-plan.md](file-cache-plan.md) & [caching-strategy.md](caching-strategy.md)
 - ✅ **GitHub private repo access** - [github-private-repo-access.md](github-private-repo-access.md)
 - ✅ **Contributor/team allocation** - [contributor-team-allocation-strategy.md](contributor-team-allocation-strategy.md)
+- ✅ **Fixture data assessment** - [generated-test-data-assessment.md](generated-test-data-assessment.md)
 
 ### Future Planning
 
 - 📋 **Parallelization** - [parallelization-plan.md](parallelization-plan.md) - Multi-worker strategy
 - 📋 **Infrastructure scaling** - [infrastructure-options.md](infrastructure-options.md) - K8s vs Docker Compose
+- 📋 **Extractor caching rollout** - [extractor-caching-plan.md](extractor-caching-plan.md) - Cache behavior and adoption
 
 ## Implementation Phases
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Welcome to the **Repository Analysis System** documentation. This folder contain
 
 _Session-by-session log of development activities, key findings, and technical insights_
 
-### �📋 [01-strategy/](01-strategy/) — Business & Planning
+### [01-strategy/](01-strategy/) — Business & Planning
 
 _For understanding what we're building and why_
 
@@ -41,6 +41,9 @@ _For getting the system running and maintaining it_
 
 - [visualization.md](03-operations/visualization.md) — Grafana dashboards, metrics, visualization design
 - [deployment-plan.md](03-operations/deployment-plan.md) — Implementation timeline, phases, checklist
+- [docker-setup.md](03-operations/docker-setup.md) — Docker environment setup and service lifecycle
+- [github-actions-tests.md](03-operations/github-actions-tests.md) — CI test execution and parity notes
+- [monitoring-extraction-progress.md](03-operations/monitoring-extraction-progress.md) — Extraction monitoring and troubleshooting
 - [session-continuity.md](03-operations/session-continuity.md) — Session management, context tracking, reproducibility
 - [feature-development-workflow.md](03-operations/feature-development-workflow.md) — Development process and PR workflow
 - [branch-protection-setup.md](03-operations/branch-protection-setup.md) — Branch protection configuration
@@ -61,7 +64,8 @@ _For planning what comes next and evaluating options_
 - [parallelization-plan.md](04-implementation/parallelization-plan.md) — Multi-worker strategy, rate limiting, scaling
 - [infrastructure-options.md](04-implementation/infrastructure-options.md) — Kubernetes vs Docker Compose evaluation, pros/cons
 - [integration-testing-priority-assessment.md](04-implementation/integration-testing-priority-assessment.md) — Testing strategy and priorities
-- [worker-instrumentation.md](04-implementation/worker-instrumentation.md) — Worker metrics and observability
+- [caching-strategy.md](04-implementation/caching-strategy.md) — Current caching design and tradeoffs
+- [extractor-caching-plan.md](04-implementation/extractor-caching-plan.md) — Extractor cache implementation plan
 - [contributor-team-allocation-strategy.md](04-implementation/contributor-team-allocation-strategy.md) — Team assignment architecture
 
 **Start here if you're**: Planning next phase, evaluating infrastructure options, scaling decisions
@@ -74,7 +78,7 @@ _For leveraging AI-powered code generation and development patterns_
 
 - [ollama-fixture-and-code-generation.md](../.ai/patterns/ollama-fixture-and-code-generation.md) — Local LLM-based code generation pattern
   - Generate test fixtures, utilities, and boilerplate code
-  - Example: `python scripts/ollama-generate.py --prompt .ai/ollama-prompts/fixture-repo-seeds.md ...`
+  - Example workflows are documented in `scripts/README.md`
   - Uses Ollama with Docker for reproducible, local AI assistance
 
 **Prompts** (`.ai/ollama-prompts/`):
@@ -140,7 +144,7 @@ _For leveraging AI-powered code generation and development patterns_
 
 ## Related Files
 
-- **[00-quick-reference.md](00-quick-reference.md)** — Quick command reference (at root level)
+- **[scripts/README.md](../scripts/README.md)** — Script entry points and Docker-first command reference
 - **[requirements.txt](../requirements.txt)** — Python dependencies
 - **[docker-compose.yml](../docker-compose.yml)** — Local development stack
 - **[src/](../src/)** — Application code
@@ -162,7 +166,7 @@ This validator enforces documentation standards from
 ## Getting Help
 
 - **Lost?** Start with your role above and read in order
-- **Need quick info?** Check [00-quick-reference.md](00-quick-reference.md)
+- **Need quick info?** Check [scripts/README.md](../scripts/README.md)
 - **Looking for specific feature?** Use [requirements-status.md](01-strategy/requirements-status.md)
 - **Want to understand a component?** Navigate to [02-architecture/](02-architecture/)
 


### PR DESCRIPTION
## Summary
- add a dedicated `Documentation Validation` GitHub Actions job for PRs and pushes
- refresh stale documentation links and navigation across the root README and docs tree
- update CI and branch-protection docs to reference the new PR checks and current Docker-first workflow

## Validation
- `bash scripts/validate-documentation.sh README.md`
- `bash scripts/validate-documentation.sh docs`
- `bash scripts/validate-documentation.sh docs/03-operations/github-actions-tests.md`
- `bash scripts/validate-documentation.sh docs/03-operations/branch-protection-setup.md`
- `bash scripts/run-tests-docker.sh`

## Notes
- docs validation passes with no violations; remaining warnings are legacy style warnings in older code-heavy docs
- branch protection should require both `Documentation Validation` and `CI Tests` if checks are selected explicitly in GitHub
