### PR TITLE
ci(docs): fix screenshot DB host connectivity

### DIFF
--- a/.github/workflows/update-docs-bot.yml
+++ b/.github/workflows/update-docs-bot.yml
@@ -117,6 +117,13 @@ jobs:
             exit $EXIT_CODE
           '
 
+          echo "Waiting for host access to screenshot database on 127.0.0.1:5432..."
+          timeout 60 bash -c '
+            until bash -c "</dev/tcp/127.0.0.1/5432" 2>/dev/null; do
+              sleep 2
+            done
+          '
+
       - name: Install screenshot dependencies
         if: inputs.run_screenshots
         run: pip install -r requirements.txt --quiet

--- a/docker-compose.screenshots.yml
+++ b/docker-compose.screenshots.yml
@@ -26,6 +26,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: devops_screenshots
       TIMESCALEDB_TELEMETRY: "off"
+    ports:
+      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -h localhost -U postgres -d devops_screenshots"]
       interval: 5s


### PR DESCRIPTION
## Summary
- publish the screenshot TimescaleDB port to the host in docker-compose.screenshots.yml
- wait explicitly for host access on 127.0.0.1:5432 before seeding
- fix the connection-refused failure seen in Actions run 24006365073

## Validation
- reproduced the failure locally: DB healthy in Docker but localhost:5432 unreachable
- verified the fix locally: 5432 published to host and localhost:5432 reachable