### PR TITLE
docs: triage implementation doc warnings (pass 1)

### DIFF
--- a/docs/04-implementation/caching-strategy.md
+++ b/docs/04-implementation/caching-strategy.md
@@ -267,3 +267,12 @@ The caching strategy is:
    - Can be manually cleared if stale
 
 This ensures all eventualities are covered.
+
+## Architecture Guardian
+
+This implementation plan stays within architecture boundaries:
+
+- Extractors remain API clients and do not own persistence logic.
+- Workflow code orchestrates extraction and cache lifecycle only.
+- Database writes remain in storage/database layers.
+- Caching concerns are isolated to extractor support utilities.

--- a/docs/04-implementation/extractor-caching-plan.md
+++ b/docs/04-implementation/extractor-caching-plan.md
@@ -115,3 +115,12 @@ Applied `@cached` decorator to:
    - `TestCacheManagement` (5 tests): initial state, stats, clear_cache, method stats tracking, fresh calls after clear
 2. **Existing tests**: ⚠️ Not re-verified in this update (tests not run)
 3. **Manual verification**: Run extraction against a repo and check DEBUG logs for cache hit messages
+
+## Architecture Guardian
+
+Guardian boundary check for this plan:
+
+- Extractor layer: cache wrappers optimize API calls but do not change ownership of business rules.
+- Workflow layer: orchestration uses cache stats/clear operations only.
+- Database layer: no new direct writes introduced by cache logic.
+- Cross-platform isolation: GitHub and Azure DevOps extractors keep platform-specific behavior separated.

--- a/docs/04-implementation/file-cache-plan.md
+++ b/docs/04-implementation/file-cache-plan.md
@@ -49,3 +49,12 @@ Add optional file-based caching to the existing extractor cache decorator so it 
 - With file cache enabled, a second run hits file cache with no API call and populates RAM cache.
 - With file cache disabled, behavior is unchanged.
 - Unit tests pass and no regression in existing cache behavior.
+
+## Architecture Guardian
+
+This file-cache extension preserves core boundaries:
+
+- Caching remains an extractor support concern, not a workflow responsibility.
+- Workflow orchestration remains unchanged and does not embed cache policy logic.
+- Storage/database layers remain the only persistence writers for analysis data.
+- Platform extractor implementations stay isolated from one another.

--- a/docs/04-implementation/generated-test-data-assessment.md
+++ b/docs/04-implementation/generated-test-data-assessment.md
@@ -136,3 +136,12 @@ offending panels under `raw_sql_offenders`.
 4. **Run this workflow on every PR** by adding a `pull_request` trigger to
    `.github/workflows/generated-test-data-assessment.yml` once the baseline
    coverage is acceptable.
+
+## Architecture Guardian
+
+Boundary validation for this assessment:
+
+- Test-data generation and audit tooling remain outside runtime extraction workflows.
+- Reporting-view validation does not introduce direct production schema writes.
+- Workflow/CI adjustments remain operational orchestration, not domain logic migration.
+- Existing extractor and database service boundaries are unchanged.

--- a/docs/04-implementation/infrastructure-options.md
+++ b/docs/04-implementation/infrastructure-options.md
@@ -234,6 +234,15 @@ kubectl set image deployment/analyzer-celery-worker worker=myregistry/worker:v2.
 
 ---
 
+## Architecture Guardian
+
+This infrastructure planning document maintains architectural boundaries:
+
+- Extractors remain platform-isolated and unchanged by deployment topology.
+- Workflow orchestration remains in workflow/task layers, independent of runtime platform.
+- Database interactions remain centralized in existing storage/database modules.
+- Infrastructure choices (Compose/Kubernetes) affect operations, not domain ownership.
+
 ## 9. Revision History
 
 | Version | Date       | Notes                    |

--- a/docs/04-implementation/integration-testing-priority-assessment.md
+++ b/docs/04-implementation/integration-testing-priority-assessment.md
@@ -300,3 +300,12 @@ Cost to Fix Issues: 1-2 hours (caught early)
 - Week 3+: Build features on proven foundation = sustainable pace
 
 **Time investment same, but confidence and quality dramatically better.**
+
+## Architecture Guardian
+
+Architecture boundary validation:
+
+- Integration tests validate existing layer responsibilities rather than moving logic between layers.
+- Workflow tests keep orchestration concerns in workflows and do not embed storage internals.
+- Database assertions remain contract-level checks against reporting/storage contracts.
+- Extractor behavior is tested as an API boundary, not coupled to downstream business rules.

--- a/docs/04-implementation/parallelization-plan.md
+++ b/docs/04-implementation/parallelization-plan.md
@@ -567,6 +567,17 @@ With 4000 GitHub requests/hour and 40 calls per repo:
 
 ---
 
+## Architecture Guardian
+
+Boundary validation for parallelization rollout:
+
+- Coordinator/worker tasks remain orchestration components; extractors stay focused on API access.
+- Platform-specific extraction logic remains separated by extractor implementation.
+- Database writes remain centralized in database/storage services.
+- Concurrency controls are operational concerns and do not alter domain ownership boundaries.
+
+---
+
 **Document Status**: ✅ Ready for Review  
 **Last Updated**: January 19, 2026  
 **Owner**: Development Team


### PR DESCRIPTION
Summary:
First cleanup pass for docs validator warnings by addressing missing Architecture Guardian sections in implementation planning docs.

Changes:
- Added Architecture Guardian sections to seven implementation docs in docs/04-implementation.
- Preserved document intent while clarifying architecture-boundary compliance.
- Kept changes documentation-only (no runtime code impact).

Validation:
- bash scripts/validate-documentation.sh docs
- Result: 0 violations, warnings reduced from 20 to 13.

Scope intentionally deferred:
- Remaining warnings are mostly high code-block density docs in architecture/operations and several implementation docs where code examples are intentional.