### PR TITLE
docs: close out plan 011 R1/R2/R3 (PR #65)

### DIFF
--- a/.ai/plans/011-technology-detection-persistence-plan.md
+++ b/.ai/plans/011-technology-detection-persistence-plan.md
@@ -1,9 +1,12 @@
 # Plan: Technology Detection Persistence & Cross-Org Analysis
 
-## Status: Mostly Complete
+## Status: Complete
 
-**Branch**: `copilot/implement-plan-011-persistence-eol-enrichment` (merged to main via PR #56)  
-**Last updated**: 2026-04-24
+**Branches**:
+- `copilot/implement-plan-011-persistence-eol-enrichment` (merged via PR #56) — foundational items
+- `copilot/review-plan-011` (merged via PR #65) — R1/R2/R3 surface-area items
+
+**Last updated**: 2026-04-25
 
 | Section | Status | Notes |
 |---------|--------|-------|
@@ -17,18 +20,18 @@
 | API endpoints | ✅ Done | `src/api/stack.py` — all 4 endpoints (`/api/stack/summary`, `by-service`, `eol`, `by-repo`) |
 | Technology Landscape dashboard | ✅ Done | `dashboards/technology-landscape.json` |
 | Contract test — dashboard SQL | ✅ Done | `tests/contract/database/test_stack_dashboard_queries.py` |
-| service-overview "Technology Stack" row | ❌ Not done | `service-overview.json` contains no `repository_stack` / `technologies` references (verified 2026-04-24) |
-| repository-deep-dive — language panels | ❌ Not done | `repository-deep-dive.json` only references `key_technologies` from summaries; no `repository_stack` queries or Technologies section (verified 2026-04-24) |
-| Fixture scenarios (EOL/stack categories) | ❌ Not done | `tests/fixtures/scenarios/config.json` has no `is_eol` / `framework` / `heuristic` entries per Addendum A (verified 2026-04-24) |
+| service-overview "Technology Stack" row (R1) | ✅ Done | Row + table panel + bar chart panel added in PR #65; SQL pinned by `TestServiceOverviewTechStackQueries` |
+| repository-deep-dive — Technologies section (R2) | ✅ Done | "Technologies (Detected Stack)" table panel with EOL highlighting added in PR #65; SQL pinned by `TestRepoDeepDiveTechQueries` |
+| Fixture scenarios (EOL/stack categories) (R3) | ✅ Done | `TECHNOLOGY_STACK_BY_TEMPLATE` in `scripts/generated/generate-repo-seeds.py`; `technology_stack` field on all 27 fixtures; e2e wiring via `FixtureExtractor.get_technology_stack()` (PR #65) |
 
 ---
 
-## Remaining Work Summary (2026-04-24)
+## Completed R1/R2/R3 — PR #65 (merged 2026-04-25)
 
-Three discrete, independent items remain. All foundational code (migration, models,
-storage, enricher, API, Technology Landscape dashboard, dashboard-SQL contract tests)
-is merged and green. What's left is surface-area extension plus the fixture coverage
-required by Addendum A.
+All three remaining items shipped together in PR #65 via the GitHub coding agent
+delegation described below. Foundational code (migration, models, storage, enricher,
+API, Technology Landscape dashboard, dashboard-SQL contract tests) had already shipped
+in PR #56. Specs for R1/R2/R3 are preserved below as the historical delivery record.
 
 ### R1 — `dashboards/service-overview.json`: add "Technology Stack" row
 - Insert after the Security row.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,53 @@
 
 ---
 
+## Session: 2026-04-25 - Plan 011 R1/R2/R3 Completed (PR #65)
+
+### Summary
+
+Closed out the three remaining surface-area items from
+[Plan 011](.ai/plans/011-technology-detection-persistence-plan.md): Technology Stack
+row on the Service Overview dashboard, Technologies panel on the Repository Deep-Dive
+dashboard, and deterministic fixture coverage for the seven non-language stack
+categories. Foundational code had been merged earlier via PR #56; PR #65 is the final
+close-out.
+
+### What Was Done
+
+- **R1** — Added "Technology Stack" row to
+  [dashboards/service-overview.json](dashboards/service-overview.json):
+  row header (id 105), `Technology Stack by Service` table (id 106), and
+  `Top Technologies (Non-Language) Across Services` bar chart (id 107).
+- **R2** — Added `Technologies (Detected Stack)` table panel (id 57) to
+  [dashboards/repository-deep-dive.json](dashboards/repository-deep-dive.json) with
+  EOL highlighting via LEFT JOIN on `technologies`.
+- **R3** — Added `TECHNOLOGY_STACK_BY_TEMPLATE` to
+  [scripts/generated/generate-repo-seeds.py](scripts/generated/generate-repo-seeds.py);
+  populated `technology_stack` on all 27 generated fixtures; added
+  `FixtureExtractor.get_technology_stack()`; wired the e2e pipeline in
+  `tests/contract/database/test_full_pipeline_e2e.py` to feed fixture stack data
+  through `store_detections()` + `store_technology_eol()`.
+- New contract tests in
+  [tests/contract/database/test_stack_dashboard_queries.py](tests/contract/database/test_stack_dashboard_queries.py)
+  pin the SQL semantics for both dashboards.
+
+### Validation
+
+- CI green on PR #65: CI Tests, Documentation Validation, Full Pipeline E2E Tests.
+- Determinism preserved — `TECHNOLOGY_STACK_BY_TEMPLATE` is a static dict, no RNG.
+
+### Pull Request
+
+- PR #65 — `copilot/review-plan-011` (merged via GitHub coding agent delegation)
+
+### Follow-up
+
+- Manual Grafana import recommended on first deployment to visually confirm panel
+  layout (gridPos `y` shifts at 49/57/58 on service-overview; 94/103/104/114 on
+  repository-deep-dive). Automated tests verify SQL but not rendering.
+
+---
+
 ## Session: 2026-04-24 - Test-Runner verify-extraction.sh Runtime Fix
 
 ### Summary

--- a/docs/03-operations/visualization.md
+++ b/docs/03-operations/visualization.md
@@ -86,6 +86,7 @@ To refresh screenshots: **Actions → Update-Docs Bot → Run workflow** (enable
 - **Security & Dependencies**: Vulnerabilities by severity, outdated/EOL deps, ecosystems, vulnerability details table
 - **Branch Health**: Active branches, staleness chart, divergence from main, branch details table
 - **Technology Stack**: Language distribution donut, AI-generated summary
+- **Technologies (Detected Stack)**: Non-language stack entries (frameworks, databases, deployment platforms, build tools, testing frameworks, CI/CD, documentation) sourced from `repository_stack` with EOL flags via LEFT JOIN on `technologies`
 - **Recent Activity**: Recent commits table, open PRs table
 
 ![Repository Deep-Dive Dashboard](../images/dashboards/repository-deep-dive.png)
@@ -146,6 +147,12 @@ To refresh screenshots: **Actions → Update-Docs Bot → Run workflow** (enable
 
 **UID**: `service-overview`
 **Purpose**: High-level service health and SLA metrics
+
+**Sections** (technology coverage added in PR #65):
+
+- **Technology Stack**:
+  - `Technology Stack by Service` table — service, languages, frameworks, EOL count (joins `repository_stack` through `repository_services`; EOL count from `technologies WHERE is_eol = true`)
+  - `Top Technologies (Non-Language) Across Services` bar chart — top 10 non-language entries (`WHERE rs.category != 'language'`) for the selected services
 
 ![Service Overview Dashboard](../images/dashboards/service-overview.png)
 


### PR DESCRIPTION
## Summary

- Flip [plan 011](.ai/plans/011-technology-detection-persistence-plan.md) status from `Mostly Complete` to `Complete`; the three previously-❌ rows (R1 service-overview row, R2 repository-deep-dive Technologies section, R3 fixture scenarios) are now ✅ and reference PR #65.
- New [PROGRESS.md](PROGRESS.md) session entry for 2026-04-25 logging the R1/R2/R3 close-out, validation, and the manual-Grafana-import follow-up.
- [docs/03-operations/visualization.md](docs/03-operations/visualization.md) updated to describe the new Technology Stack panels on Service Overview and the Technologies (Detected Stack) panel on Repository Deep-Dive.

Doc-only — no code changes.

## Test plan

- [x] `bash scripts/validate-documentation.sh docs/03-operations/visualization.md` passes (0 violations, 0 warnings)
- [ ] Reviewer eyeballs the plan 011 status table to confirm the flip is accurate
- [ ] Reviewer confirms PROGRESS.md follow-up note (manual Grafana import) is the right level of caveat

🤖 Generated with [Claude Code](https://claude.com/claude-code)