### PR TITLE
Fix docker test migration reruns and tighten CI test scope

### DIFF
--- a/.github/workflows/e2e-pipeline-tests.yml
+++ b/.github/workflows/e2e-pipeline-tests.yml
@@ -112,3 +112,14 @@ jobs:
         run: |
           pytest tests/contract/database/test_full_pipeline_e2e.py \
             -v --tb=short --durations=10 -m "not live_api"
+
+      - name: Run adversarial scenario smoke tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ANALYZER_GITHUB_TOKEN || github.token }}
+          TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_azure_devops
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_azure_devops
+        run: |
+          pytest tests/contract/integration/test_adversarial_scenarios.py \
+            -v --tb=short --durations=10 -m "not live_api" \
+            -k "mixed-case-emails or ghost-author"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,9 @@ jobs:
             CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
           fi
 
-          PYTHON_CHANGES=$(echo "$CHANGED_FILES" | grep -E '\.py$' | wc -l)
+          # Python test scope includes core code plus DB/schema/migration and CI plumbing
+          # that can affect runtime behavior without changing .py files.
+          PYTHON_CHANGES=$(echo "$CHANGED_FILES" | grep -E '(^|/)src/|(^|/)tests/|\.py$|(^|/)database/|\.sql$|(^|/)docker/scripts/|(^|/)scripts/run-tests-docker\.sh$|(^|/)scripts/run_migrations\.sh$|(^|/)requirements\.txt$|(^|/)pyproject\.toml$|(^|/)docker-compose\.test\.yml$|^\.github/workflows/tests\.yml$|^\.github/workflows/e2e-pipeline-tests\.yml$' | wc -l)
           BATS_CHANGES=$(echo "$CHANGED_FILES" | grep -E '\.(sh|bash|bats)$' | wc -l)
 
           if [ "$PYTHON_CHANGES" -gt 0 ]; then

--- a/docker/scripts/run_migrations.sh
+++ b/docker/scripts/run_migrations.sh
@@ -126,12 +126,18 @@ for migration_file in "$MIGRATIONS_DIR"/*.sql; do
         log_success "Applied migration: $migration_name"
         MIGRATION_APPLIED=$((MIGRATION_APPLIED + 1))
     else
-        # Check if the error is about already existing columns/tables (idempotent)
+        # Re-run once with captured output for idempotency/error classification.
+        # Disable errexit briefly so we can inspect psql failures instead of exiting early.
+        set +e
         OUTPUT=$(PGPASSWORD="$POSTGRES_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f "$migration_file" 2>&1)
+        RETRY_EXIT_CODE=$?
+        set -e
 
-        if echo "$OUTPUT" | grep -q "already exists\|duplicate"; then
+        if echo "$OUTPUT" | grep -Eiq "already exists|duplicate"; then
             log_info "Migration already applied: $migration_name"
             MIGRATION_SKIPPED=$((MIGRATION_SKIPPED + 1))
+        elif [ $RETRY_EXIT_CODE -ne 0 ]; then
+            log_error "Migration failed: $migration_name\n$OUTPUT"
         else
             log_warning "Migration had warnings: $migration_name"
             log_info "Output: $OUTPUT"

--- a/scripts/run-tests-docker.sh
+++ b/scripts/run-tests-docker.sh
@@ -152,7 +152,9 @@ start_test_db_and_migrations() {
 run_pytest_in_runner() {
     local pytest_cmd="$1"
     local exit_code=0
-    docker compose --env-file "$RESOLVED_ENV_FILE" -f "$COMPOSE_FILE" run --rm test-runner \
+    # Dependencies are started explicitly in start_test_db_and_migrations.
+    # Avoid re-running one-shot services like test-migrations for every pytest call.
+    docker compose --env-file "$RESOLVED_ENV_FILE" -f "$COMPOSE_FILE" run --rm --no-deps test-runner \
         sh -c "pip install pytest pytest-cov pytest-asyncio pytest-mock && ${pytest_cmd}" || exit_code=$?
     return $exit_code
 }


### PR DESCRIPTION
## Summary
- prevent docker test runner invocations from re-running one-shot migration dependencies
- improve migration failure handling so errors are classified correctly under set -e
- expand CI change detection so database, schema, migration, and pipeline file changes trigger Python tests
- add adversarial integration smoke coverage to the E2E pipeline workflow

## Validation
- ran focused docker test path for startup and migration flow
- verified workflow diffs for test scope and E2E adversarial smoke step