### PR TITLE
Make migrations idempotent and harden startup/migration flow

### DIFF
--- a/Start-RepoAnalysis.sh
+++ b/Start-RepoAnalysis.sh
@@ -99,8 +99,20 @@ start_infrastructure() {
         write_info "Pulling Docker images..."
         run_docker_compose pull >/dev/null 2>&1
 
+        # db-migrations embeds the migration runner script in the image.
+        # Rebuild it so script changes are always picked up.
+        write_info "Building migration image (to avoid stale migration runner)..."
+        run_docker_compose build "$DOCKER_MIGRATION_SERVICE" >/dev/null
+
         write_info "Starting all services (scheduler, celery-beat, workers, monitoring)..."
-        run_docker_compose up -d >/dev/null 2>&1
+        local up_output
+        if ! up_output=$(run_docker_compose up -d 2>&1); then
+            write_error "Docker services failed to start"
+            echo "$up_output"
+            write_info "Recent db-migrations logs:"
+            run_docker_compose logs --no-color --tail 80 "$DOCKER_MIGRATION_SERVICE" || true
+            return 1
+        fi
 
         write_info "Waiting for services to be healthy..."
         wait_for_healthy "analyzer-timescaledb" "$MAX_HEALTH_CHECK_RETRIES" "$HEALTH_CHECK_INTERVAL" >/dev/null
@@ -115,11 +127,14 @@ initialize_database() {
         cd "$PROJECT_ROOT" || exit 1
 
         write_info "Starting database migration service..."
-        if ! run_docker_compose run --rm "$DOCKER_MIGRATION_SERVICE" >/dev/null 2>&1; then
-            write_warning "Migration service completed with warnings (this may be OK if migrations already applied)"
-        else
-            write_success "Database schema and migrations initialized successfully"
+        if ! run_docker_compose run --rm "$DOCKER_MIGRATION_SERVICE"; then
+            write_error "Migration service failed"
+            write_info "Recent db-migrations logs:"
+            run_docker_compose logs --no-color --tail 120 "$DOCKER_MIGRATION_SERVICE" || true
+            return 1
         fi
+
+        write_success "Database schema and migrations initialized successfully"
     )
 }
 

--- a/database/migrations/011_add_reporting_views.sql
+++ b/database/migrations/011_add_reporting_views.sql
@@ -1,5 +1,28 @@
 -- Migration 011: Add reporting views for Grafana dashboards
 
+-- Re-applying this snapshot after migration 014 can fail because 014 renames
+-- dependencies -> repository_dependencies and removes vulnerabilities.dependency_id.
+-- Skip this migration when the legacy dependency schema is no longer present.
+SELECT CASE
+        WHEN EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = 'public'
+                    AND table_name = 'dependencies'
+        )
+        AND EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                    AND table_name = 'vulnerabilities'
+                    AND column_name = 'dependency_id'
+        )
+        THEN 1
+        ELSE 0
+END AS migration_011_can_apply\gset
+
+\if :migration_011_can_apply
+
 -- Keep reporting logic in one place to avoid drift between migration SQL and view definitions.
 
 -- NOTE: This is a static snapshot of views.sql as of migration 011.
@@ -1381,3 +1404,7 @@ LEFT JOIN
     team_metrics tm ON t.team_id = tm.team_id
 GROUP BY 
     t.team_id, t.name, t.organization_id;
+
+\else
+\echo 'Skipping migration 011_add_reporting_views.sql: legacy dependencies schema not present'
+\endif

--- a/database/migrations/013_fix_platform_pr_id_constraint.sql
+++ b/database/migrations/013_fix_platform_pr_id_constraint.sql
@@ -19,5 +19,15 @@ ALTER TABLE pull_requests
     DROP CONSTRAINT IF EXISTS uq_pull_requests_platform_pr_id;
 
 -- Step 2: Add the composite unique constraint.
-ALTER TABLE pull_requests
-    ADD CONSTRAINT uq_pr_repo_platform_pr_id UNIQUE (repo_id, platform_pr_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'uq_pr_repo_platform_pr_id'
+          AND conrelid = 'pull_requests'::regclass
+    ) THEN
+        ALTER TABLE pull_requests
+            ADD CONSTRAINT uq_pr_repo_platform_pr_id UNIQUE (repo_id, platform_pr_id);
+    END IF;
+END $$;

--- a/database/migrations/014_normalise_packages.sql
+++ b/database/migrations/014_normalise_packages.sql
@@ -31,17 +31,26 @@ END $$;
 -- Pick the most recently-seen row per (package_name, ecosystem) for metadata.
 -- has_vulnerabilities is intentionally NOT migrated — it is version-specific
 -- and will be recomputed per-repo as has_known_vulnerabilities on the next scan.
-INSERT INTO packages (package_name, ecosystem, latest_version, is_eol, eol_date, enriched_at)
-SELECT DISTINCT ON (package_name, ecosystem)
-    package_name,
-    ecosystem,
-    latest_version,
-    is_eol,
-    eol_date,
-    NOW()
-FROM dependencies
-ORDER BY package_name, ecosystem, last_seen_at DESC
-ON CONFLICT (package_name, ecosystem) DO NOTHING;
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'dependencies'
+    ) THEN
+        INSERT INTO packages (package_name, ecosystem, latest_version, is_eol, eol_date, enriched_at)
+        SELECT DISTINCT ON (package_name, ecosystem)
+            package_name,
+            ecosystem,
+            latest_version,
+            is_eol,
+            eol_date,
+            NOW()
+        FROM dependencies
+        ORDER BY package_name, ecosystem, last_seen_at DESC
+        ON CONFLICT (package_name, ecosystem) DO NOTHING;
+    END IF;
+END $$;
 
 -- ── Phase 3: Add package_id to vulnerabilities and populate it ────────────────
 DO $$ BEGIN
@@ -53,12 +62,28 @@ DO $$ BEGIN
     END IF;
 END $$;
 
-UPDATE vulnerabilities v
-SET package_id = p.id
-FROM dependencies d
-JOIN packages p ON p.package_name = d.package_name AND p.ecosystem = d.ecosystem
-WHERE v.dependency_id = d.id
-  AND v.package_id IS NULL;
+DO $$ BEGIN
+        IF EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = 'public'
+                    AND table_name = 'dependencies'
+        )
+        AND EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                    AND table_name = 'vulnerabilities'
+                    AND column_name = 'dependency_id'
+        ) THEN
+                UPDATE vulnerabilities v
+                SET package_id = p.id
+                FROM dependencies d
+                JOIN packages p ON p.package_name = d.package_name AND p.ecosystem = d.ecosystem
+                WHERE v.dependency_id = d.id
+                    AND v.package_id IS NULL;
+        END IF;
+END $$;
 
 -- Make package_id NOT NULL and add FK only when all rows are populated
 DO $$ BEGIN

--- a/docker/scripts/run_migrations.sh
+++ b/docker/scripts/run_migrations.sh
@@ -91,14 +91,16 @@ else
     log_warning "For production use, ensure the timescaledb/timescaledb Docker image is used."
 fi
 
-# Check if schema already exists
-log_info "Checking if database schema exists..."
-SCHEMA_EXISTS=$(PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -t -c "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'organizations';" 2>/dev/null || echo "0")
+# Detect whether this database already had user tables before this run.
+# This avoids relying on a hard-coded sentinel table name.
+log_info "Detecting existing schema state..."
+PRE_EXISTING_TABLES=$(PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -t -c \
+    "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE';" 2>/dev/null || echo "0")
 
-if [ "$SCHEMA_EXISTS" -gt 0 ]; then
-    log_info "Database schema already exists, skipping initial schema creation"
+if [ "$PRE_EXISTING_TABLES" -gt 0 ]; then
+    log_info "Detected existing schema ($PRE_EXISTING_TABLES public tables), skipping initial schema creation"
 else
-    log_info "Creating initial database schema..."
+    log_info "No existing schema detected; creating initial database schema..."
     if PGPASSWORD="$POSTGRES_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f "$SCHEMA_FILE" >/dev/null 2>&1; then
         log_success "Database schema initialized"
     else
@@ -117,19 +119,11 @@ TRACKING_TABLE_EXISTED=$(PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST
 PGPASSWORD="$POSTGRES_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c \
     "CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW());" >/dev/null 2>&1
 
-# Use the 'packages' table (created by migration 014) as the bootstrap indicator.
-# 'repositories' is created by schema.sql on every fresh database, so checking
-# it would incorrectly trigger the bootstrap on a brand-new install.  'packages'
-# only exists when migration 014 (or later) has actually been applied, which is
-# the correct signal that this is a pre-tracking deployment rather than a fresh one.
-CORE_TABLES_EXIST=$(PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -t -c \
-    "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'packages';" 2>/dev/null || echo "0")
-
-if [ "$TRACKING_TABLE_EXISTED" -eq 0 ] && [ "$CORE_TABLES_EXIST" -gt 0 ]; then
-    # The tracking table is brand-new but the schema already contains the 'packages'
-    # table (created by migration 014), so this is a pre-existing deployment that
-    # predates migration tracking.  Record every migration file as already applied
-    # so none of them will be re-executed.
+if [ "$TRACKING_TABLE_EXISTED" -eq 0 ] && [ "$PRE_EXISTING_TABLES" -gt 0 ]; then
+    # The tracking table is brand-new but this database already had public tables
+    # before this run, so this is a pre-existing deployment that predates migration
+    # tracking. Record every migration file as already applied so none of them
+    # will be re-executed.
     log_warning "Detected existing schema without migration tracking — backfilling all known migrations as already applied."
     for migration_file in "$MIGRATIONS_DIR"/*.sql; do
         if [ ! -f "$migration_file" ]; then

--- a/tests/contract/database/test_migration_tracking.py
+++ b/tests/contract/database/test_migration_tracking.py
@@ -12,13 +12,31 @@ is exercised.
 import glob
 import os
 import subprocess
+from urllib.parse import urlparse
 
 import pytest
 
-_POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "localhost")
-_POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5432")
-_POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")
-_POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "postgres")
+_DB_URL = os.environ.get("TEST_DATABASE_URL") or os.environ.get("DATABASE_URL", "")
+
+
+def _env_db_settings():
+    if _DB_URL:
+        parsed = urlparse(_DB_URL)
+        host = parsed.hostname or os.environ.get("POSTGRES_HOST", "localhost")
+        port = str(parsed.port or os.environ.get("POSTGRES_PORT", "5432"))
+        user = parsed.username or os.environ.get("POSTGRES_USER", "postgres")
+        password = parsed.password or os.environ.get("POSTGRES_PASSWORD", "postgres")
+        return host, port, user, password
+
+    return (
+        os.environ.get("POSTGRES_HOST", "localhost"),
+        os.environ.get("POSTGRES_PORT", "5432"),
+        os.environ.get("POSTGRES_USER", "postgres"),
+        os.environ.get("POSTGRES_PASSWORD", "postgres"),
+    )
+
+
+_POSTGRES_HOST, _POSTGRES_PORT, _POSTGRES_USER, _POSTGRES_PASSWORD = _env_db_settings()
 
 # Support both CI (GitHub Actions runner, GITHUB_WORKSPACE set) and Docker
 # (test-runner container where the repo is mounted at /app).
@@ -86,6 +104,10 @@ def _run_migration_script(db):
 
 def _count_migration_files():
     return len(glob.glob(f"{_MIGRATIONS_DIR}/*.sql"))
+
+
+def _migration_filenames():
+    return sorted(os.path.basename(path) for path in glob.glob(f"{_MIGRATIONS_DIR}/*.sql"))
 
 
 @pytest.fixture()
@@ -254,3 +276,33 @@ class TestMigrationTracking:
         assert "011_add_reporting_views.sql" in recorded_011, (
             "011_add_reporting_views.sql must be recorded in schema_migrations after bootstrap"
         )
+
+    def test_replay_each_migration_on_migrated_db(self, temp_db):
+        """Contract: each migration can be replayed safely on an already-migrated DB.
+
+        For every migration file, remove only its tracking row and rerun the
+        migration runner. The rerun must succeed and re-record that migration.
+        """
+        first = _run_migration_script(temp_db)
+        assert first.returncode == 0
+
+        for migration_name in _migration_filenames():
+            _psql(
+                temp_db,
+                f"DELETE FROM schema_migrations WHERE version = '{migration_name}';"
+            )
+
+            rerun = _run_migration_script(temp_db)
+            assert rerun.returncode == 0, (
+                f"Replay failed for {migration_name}.\n"
+                f"stdout:\n{rerun.stdout}\n"
+                f"stderr:\n{rerun.stderr}"
+            )
+
+            recorded = _psql_query(
+                temp_db,
+                f"SELECT COUNT(*) FROM schema_migrations WHERE version = '{migration_name}';"
+            )
+            assert recorded == "1", (
+                f"Expected exactly one tracking row after replay for {migration_name}, got {recorded}"
+            )


### PR DESCRIPTION
## Summary
- make migration execution and startup diagnostics more robust in local/dev flows
- remove hard-coded schema sentinel logic in migration runner
- add idempotency guards to legacy migrations that could fail on replayed or partially migrated databases
- add contract coverage to enforce migration replay safety

## Changes
- `Start-RepoAnalysis.sh`
  - rebuild `db-migrations` image before startup to avoid stale embedded runner scripts
  - surface `docker compose up` errors instead of suppressing output
  - print recent migration logs on startup/migration failure

- `docker/scripts/run_migrations.sh`
  - replace hard-coded `organizations` table existence gate with generic public table-count detection
  - preserve schema bootstrap/backfill behavior using generic pre-existing-schema detection

- `database/migrations/011_add_reporting_views.sql`
  - add conditional guard to skip applying legacy dependency-based view definitions when post-014 schema is present

- `database/migrations/013_fix_platform_pr_id_constraint.sql`
  - make composite constraint creation idempotent via existence check in `pg_constraint`

- `database/migrations/014_normalise_packages.sql`
  - guard dependency-based data migration steps so reruns are safe when `dependencies`/`dependency_id` no longer exist

- `tests/contract/database/test_migration_tracking.py`
  - add `test_replay_each_migration_on_migrated_db` to replay each migration by removing its tracking row and asserting rerun success
  - derive DB connection settings from `TEST_DATABASE_URL`/`DATABASE_URL` first so Docker contract tests resolve the correct host

## Validation
- Docker startup flow verified with `./Start-RepoAnalysis.sh`
- Focused Docker contract test:
  - `./scripts/run-tests-docker.sh tests/contract/database/test_migration_tracking.py::TestMigrationTracking::test_replay_each_migration_on_migrated_db`
- Full migration tracking contract suite in Docker:
  - `./scripts/run-tests-docker.sh tests/contract/database/test_migration_tracking.py`
  - result: `6 passed`
