### PR TITLE
Plan 025 closeout: investigation resolved, plans aligned, Wave 1 prompts ready

### DIFF
--- a/.ai/investigations/grafana-ui-shortcomings.md
+++ b/.ai/investigations/grafana-ui-shortcomings.md
@@ -1,0 +1,271 @@
+# Investigation: Grafana UI Shortcomings — Navigation, Relational Drill-down, and Tool Fit
+
+**Status**: RESOLVED 2026-05-03 — **Outcome 2 selected** (split admin from analytics; bespoke admin UI + tidied Grafana). Proceed with [Plan 024](../plans/024-bespoke-admin-and-navigation-ui.md).
+**Created**: 2026-05-01
+**Related plans**: `.ai/plans/023-grafana-home-dashboard-links.md` (home nav links — closed), `.ai/plans/024-bespoke-admin-and-navigation-ui.md` (approved React UI)
+
+---
+
+## Why this exists
+
+The user has identified two specific frustrations with the current Grafana setup:
+
+1. **Cross-dashboard navigation is messy** — jumping back to root or sideways to a sibling dashboard requires either the static top-link bar (inconsistently populated per dashboard) or Grafana's general search.
+2. **Relational drill-down is incomplete** — particularly on the security dashboard: a row that says "repository X has vulnerability Y" doesn't always let the user click through to the repository's deep-dive view. Vulnerability-centric tables (e.g. "Top Vulnerable Dependencies") are dead ends.
+
+Plus a broader question about scope: Grafana is being asked to do **two different jobs** — analytics (the natural fit) and admin/operational control (rescan triggers, metric computes — currently embedded as HTML link buttons in `dashboards/admin-dashboard.json`). The hypothesis is that the second job is the wrong tool, and that explains a lot of the friction.
+
+The goal of this investigation is to map the friction concretely before deciding how to spend effort: tidy what we have, rebuild some of it, or split the concerns.
+
+---
+
+## What we know already (from reading the dashboards)
+
+- 12 dashboards in `dashboards/*.json`. Top-link bars are inconsistent: `admin-dashboard.json` has 1 link (Home), `security-dashboard.json` has 8, `dependency-vulnerability-portfolio.json` has 4.
+- Drill-down via Grafana data links **does** exist on at least these tables:
+  - `security-dashboard.json:658` → `Repository Security Overview` table → `repo-deep-dive`
+  - `dependency-vulnerability-portfolio.json` → library detail (per Plan 021)
+    Other tables (e.g. "Top Vulnerable Dependencies", severity breakdowns) have no row-level drill-down.
+- The admin dashboard is unusual: extraction is triggered by a `text`/`stat` panel link that POSTs to `http://localhost:5000/api/rescan/github` (the Flask API). It works, but it's a UX of "click a Grafana stat tile and watch a browser tab open showing JSON".
+- A rescan/health/packages/radar/stack Flask API is already exposed (~20 endpoints in [src/api/rescan.py](src/api/rescan.py) and [src/api/stack.py](src/api/stack.py)) — any new frontend has a server to talk to.
+- Plan 023 just shipped to fix Home → child-dashboard discoverability. That's the _outbound_ nav from Home; the _inbound_ return-to-Home and _sideways_ sibling nav are still uneven.
+
+---
+
+## Themes to investigate
+
+Each theme is a set of questions the user (or a contributor) should answer before committing to a direction. Keep answers short — one or two sentences each is usually enough.
+
+### Theme A — Cross-dashboard navigation
+
+_Goal: characterise where the navigation actually breaks down._
+
+1. When you're on a non-Home dashboard and want to get back to Home, what do you currently do? (top-link, browser back, Grafana sidebar?)
+2. When you're on Security and want to jump to Technology Landscape, how many clicks does it take? Where do you look first?
+3. Is the inconsistency of top-link bars (1 vs 8 links per dashboard) the actual annoyance, or is it the absence of a consistent "you are here" hierarchy?
+4. Would a uniform top-link bar (Home / Repos / Security / Tech / Admin) on every dashboard fix it, or does the issue remain even with that?
+5. Is there a use-case for breadcrumb-style nav ("Home › Security › Repository X")? Grafana doesn't do this natively.
+
+**Answers:**
+
+1. I click the navigation top-link
+2. It takes 2 clicks and some scrolling (1 click to home, scroll down the home page to find technology landscape, then have to scroll the panel to find the link, then click the link)
+3. Missing "you are here" hierarchy and inconsistent navigation - ideally we would want to click on any category and "go there", if a data row has users, i should be able to click to that user's dashboard, if a datarow shows repositories i should be able to click and go to that repo dashboard
+4. consistent top-link would help
+5. dont need breadcrumb-style navigation
+
+---
+
+### Theme B — Relational drill-down
+
+_Goal: list the missing edges in the data graph._
+
+1. On the security dashboard, list every panel where you've wished you could click a row and weren't able to. (e.g. "Top Vulnerable Dependencies → which repos use this?", "EOL Status → which repos?")
+2. Are these missing because the data is there but the data link wasn't configured, or because the underlying SQL doesn't expose the join key?
+3. For each missing edge, what is the natural drill-down target? (a repo deep-dive, a library deep-dive, a service overview, a team page?)
+4. Is the friction "I can't get there at all" or "I can get there but it's two manual steps via a search box"?
+5. Are there panels you'd actively _prevent_ drill-down from? (e.g. aggregate trend lines that would make no sense as link targets)
+
+**Answers:**
+
+1. "top vulnerable dependencies" should allow me to view the associated repos and then navigate into them, "EOL status" should also support this. Although note the lack of data makes this difficult to test
+2. I believe the data is there, just not configured
+3. top vulnerable, go to library deep-dive and then the repos that use it
+4. the friction is no navigation at all
+5. no panels should prevent drilldown as long as there is a dashboard to navigate to that shows that unique item
+   Example missing use-case, in the organizaiton security summary, we have 10 total vulnerabilities and 4 repositories but no way to get to them, the repository security overview shows all repos and zeros for every column
+
+---
+
+### Theme C — Admin / operational workflows in Grafana
+
+_Goal: confirm whether admin belongs in Grafana at all._
+
+1. Today, what are the admin actions you actually perform from `admin-dashboard.json`? (Trigger rescan, recompute service metrics, check API health, see Flower, look at stale repos…)
+2. Which of those feel comfortable in Grafana, and which feel like fighting the tool?
+3. When you trigger a rescan, what feedback do you get? (the API returns JSON in a new tab — is that acceptable, or do you want the running job's progress in-place?)
+4. Is there a workflow you've avoided implementing because it would be too painful to express as a Grafana panel? (e.g. "exclude this repo from scans", "tag this team as inactive", "edit a service-to-repo mapping")
+5. If admin moved to a separate web UI tomorrow, what would you keep in Grafana? (probably: Active Runs, Recent Runs, Auth Failures, Repository Staleness — i.e. the read-only operational _observability_ panels)
+
+**Answers:**
+
+1. I use it to start analysis
+2. Starting the analysis does not feel right
+3. when you trigger a rescan, you are taken to a new window with the queue/job information, there is no nice popup to say "your scan request has been logged and will start soon" from within grafana
+4. i havent excluded a particular workflow for that reason
+5. i would keep the observability panels as you suggest
+
+---
+
+### Theme D — Analytics tool fit
+
+_Goal: separate "Grafana is wrong" from "this Grafana isn't great"._
+
+1. For the analytics dashboards specifically (security, technology landscape, dependency portfolio, library detail, repo overview, team, service, contributors, PRs) — is the issue ever Grafana's data model (can't express the chart you want), or is it always navigation/drill-down?
+2. Have you hit a query you couldn't write in Grafana's SQL editor? (suggests a tool ceiling)
+3. Have you wanted a custom interaction Grafana can't render? (e.g. a faceted search, a sortable table with multi-column filters, a timeline scrubber, a graph visualisation of dependencies between packages)
+4. If we kept Grafana for charts and put navigation/drill-down on top of it, would that solve it? Or do specific dashboards need to leave Grafana entirely?
+
+**Answers:**
+
+1. Navigation is somewhat painful, and the panels can feel cluttered and have scrollbars to find links/etc
+2. no
+3. no. But the visualisation between packages seems like a cool idea and i believe there is a visualisation for that
+4. grafana for charts and analysis and alerts is great, perhaps the diagnostics (did the scan work?) and details are the problem
+
+---
+
+### Theme E — Effort and audience
+
+_Goal: anchor the decision in real cost and real users._
+
+1. Who uses these dashboards? (you alone, a small team, leadership, external stakeholders?) Different audiences justify different investments.
+2. What does "good enough" look like — would tidying the top-link bar across all 12 dashboards and adding the missing data links satisfy 80% of the pain?
+3. How much time per week is currently lost to nav/drill-down friction? (rough estimate)
+4. Are you willing to maintain a small bespoke React app long-term (deps, builds, security patches), or is that a cost you'd regret in six months?
+
+**Answers:**
+
+1. these will be used by team and leadership, as there will be many teams
+2. yes
+3. 20% of my time is one-hit debugging, so i think this is an unfair question at current usage
+4. yes im happy to maintain the app
+
+---
+
+## Synthesis — decision matrix
+
+Once Themes A–E have answers, map them to one of three outcomes. The investigation isn't done until this table is filled.
+
+| Outcome                                                    | Justified when…                                                                                                                                        | Effort                                                    | Reversibility                                       |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- | --------------------------------------------------- |
+| **(1) Tidy Grafana only**                                  | Theme A is the dominant pain, Themes C/D answers don't surface tool-fit problems, Theme E says "no budget for bespoke"                                 | ~1–2 days (uniform top-link bar + add missing data links) | Trivial                                             |
+| **(2) Split: bespoke admin UI + tidied Grafana analytics** | Theme C surfaces real tool-fit pain (admin in Grafana feels wrong), Theme D says analytics is mostly fine, Theme E supports modest ongoing maintenance | ~1–2 weeks for admin MVP + the Outcome 1 work             | Reversible — admin UI can be deleted, Grafana stays |
+| **(3) Replace analytics tool too**                         | Theme D surfaces ceiling problems (queries Grafana can't express, interactions it can't render)                                                        | Multi-week migration to Metabase/Superset/bespoke         | Hard — dashboards are real assets                   |
+
+**Pre-investigation lean** (to be confirmed by answers): Outcome 2. Plan 024 is drafted on that assumption.
+
+**Resolution (2026-05-03): Outcome 2 confirmed.**
+
+| Theme | Signal | Mapped to outcome |
+| --- | --- | --- |
+| A — Navigation | Wants consistent top-link bar; wants click-through from any data row to its target dashboard. No breadcrumbs needed. | Tidy Grafana (Phase 2/3 of Plan 024) |
+| B — Drill-down | Friction is "no navigation at all" rather than slow nav. Data is there, just unconfigured. All panels with a unique target should drill down. | Tidy Grafana (Phase 3 of Plan 024) |
+| C — Admin | Only "start analysis" is used today. Does NOT feel right in Grafana. New-tab JSON feedback is bad UX. | Out of Grafana (Phase 1 of Plan 024) |
+| D — Tool fit | Grafana fine for charts/alerts. No query ceiling. Diagnostics/details and panel clutter are the actual issues. | Keep Grafana for analytics |
+| E — Effort | Team + leadership audience. Tidy nav + missing data links would solve ~80% of pain. Happy to maintain a small React app. | Outcome 2 viable |
+
+**80/20 implication**: Phases 2 + 3 of Plan 024 (Grafana tidy, ~2–3 days) capture most of the value. Phase 1 (React MVP, ~1–2 weeks) addresses the remaining admin pain. Plan 024 has been re-sequenced accordingly. RESOLVED
+
+---
+
+## Concrete artefacts to produce alongside the answers
+
+1. **Top-link audit** — a table listing each dashboard and its current top-link entries, so the inconsistency is visible at a glance.
+   ```bash
+   for f in dashboards/*.json; do
+     echo "=== $f ==="
+     jq -r '.links[] | "  \(.title) -> \(.url)"' "$f"
+   done
+   ```
+2. **Drill-down audit** — for each table panel in security, dependency-vulnerability-portfolio, library-detail-deep-dive, technology-landscape: does the row have a data link? Where does it go?
+   ```bash
+   jq '[.panels[] | select(.type=="table") | {title, has_link: (.fieldConfig.overrides // [] | any(.properties[]?.id == "links"))}]' dashboards/security-dashboard.json
+   ```
+3. **Admin action inventory** — list every action panel in `admin-dashboard.json` with the API endpoint it calls and the user feedback it gives today.
+
+These three artefacts make Themes A, B, and C answerable from data instead of memory.
+
+---
+
+## Next step
+
+When the synthesis table is at least half filled in, decide between Outcomes 1, 2, 3. If Outcome 2 (the current lean), proceed with [Plan 024](../plans/024-bespoke-admin-and-navigation-ui.md). If Outcome 1, scope a smaller "Grafana navigation hardening" plan instead. If Outcome 3, this becomes a much larger conversation.
+
+---
+
+## Risks of skipping this investigation
+
+- Building Plan 024's React UI without confirming Theme C means we might over-build (rebuilding things Grafana actually does well) or under-build (missing the actual workflows that motivate the rebuild).
+- Tidying Grafana without confirming Theme D means we may sink time into a tool that has a ceiling we haven't acknowledged.
+- 30–60 min of structured Q&A here probably saves a week of misdirected work.
+
+---
+
+## Audit findings (2026-05-03)
+
+These three audits make Phases 2 and 3 of Plan 024 mechanical to execute. Snapshot from `main` at the time of investigation closure.
+
+### 1. Top-link audit
+
+7 distinct shapes across 12 dashboards. Inconsistent ordering, inconsistent membership.
+
+| Dashboard | Top-link entries |
+| --- | --- |
+| `admin-dashboard.json` | Home |
+| `contributor-analytics.json` | Home, Team Overview, Repository Overview, Repository Deep-Dive, Pull Requests |
+| `dashboard-home.json` | (none — it IS Home) |
+| `dependency-vulnerability-portfolio.json` | Home, Security, Library Deep-Dive |
+| `library-detail-deep-dive.json` | Home, Package Portfolio, Security |
+| `pull-requests.json` | Home, Team Overview, Repository Overview, Repository Deep-Dive, Contributors |
+| `repository-deep-dive.json` | Home, Team Overview, Repository Overview, Pull Requests, Contributors |
+| `repository-overview.json` | Home, Team Overview, Repository Deep-Dive, Pull Requests, Contributors |
+| `security-dashboard.json` | Home, Team Overview, Repository Overview, Repository Deep-Dive, Pull Requests, Contributors |
+| `service-overview.json` | Home, Repository Overview, Team Overview, Security |
+| `team-overview.json` | Home, Repository Overview, Repository Deep-Dive, Pull Requests, Contributors |
+| `technology-landscape.json` | (none — regression) |
+
+**Phase 2 implication**: a uniform 5-entry bar (Home / Repos / Security / Technology / Admin) replaces all of the above. `dashboard-home.json` keeps no bar; everything else gets the same bar.
+
+### 2. Drill-down audit
+
+Most table panels have NO row-level data link. `[LINK]` = has data link configured; `[----]` = missing.
+
+| Dashboard | Panel | Status | Natural target |
+| --- | --- | --- | --- |
+| security-dashboard | Repository Security Overview | [LINK] | (already drills to repo-deep-dive) |
+| security-dashboard | Top Vulnerable Dependencies | [----] | library-detail-deep-dive |
+| dependency-vulnerability-portfolio | Top 20 Vulnerable Packages | [----] | library-detail-deep-dive |
+| dependency-vulnerability-portfolio | Packages Reaching EOL Within 90 Days | [----] | library-detail-deep-dive |
+| dependency-vulnerability-portfolio | Package Usage by Team | [----] | team-overview / library-detail-deep-dive |
+| library-detail-deep-dive | Health Status | [----] | (review — may not need drill-down) |
+| library-detail-deep-dive | CVE Details | [----] | (external — CVE link) |
+| library-detail-deep-dive | Repositories Using $package_name | [----] | repo-deep-dive **(highest-value gap)** |
+| technology-landscape | EOL Technologies with Affected Repo Count | [----] | repo-deep-dive (filtered) |
+| technology-landscape | Repository Stack (by source) | [----] | repo-deep-dive |
+| repository-deep-dive | Vulnerability Details | [----] | library-detail-deep-dive |
+| repository-deep-dive | Branch Details | [----] | (no obvious target — skip) |
+| repository-deep-dive | Repository Summary | [----] | (no obvious target — skip) |
+| repository-deep-dive | Technologies (Detected Stack) | [----] | technology-landscape (filtered) |
+| repository-deep-dive | Recent Commits | [----] | (external — git host) |
+| repository-deep-dive | Open Pull Requests | [----] | pull-requests |
+| repository-overview | Top 10 Active Repositories | [LINK] | (already drills) |
+| repository-overview | All Repositories | [LINK] | (already drills) |
+| team-overview | Repository Health Matrix | [LINK] | (already drills) |
+| team-overview | Team Performance Summary | [----] | repo-overview (filtered by team) |
+| team-overview | Recent Pull Requests (7 Days) | [LINK] | (already drills) |
+| service-overview | Services at a Glance | [----] | service-overview detail (same dashboard, drilled) |
+| service-overview | Technology Stack by Service | [----] | technology-landscape (filtered) |
+| service-overview | Repository Breakdown | [LINK] | (already drills) |
+
+**Phase 3 implication**: ~10 high-value gaps to close. Each is a small `fieldConfig.overrides[]` JSON edit. The user's specific complaint (org security summary → underlying repos) is the "Top Vulnerable Dependencies" + "Repositories Using $package_name" chain, both flagged.
+
+### 3. Admin action inventory
+
+| Panel | Type | Endpoint | Current feedback |
+| --- | --- | --- | --- |
+| Force Rescan — GitHub | stat | `POST http://localhost:5000/api/rescan/github` | Opens new tab with raw JSON |
+| Force Rescan — Azure DevOps | stat | `POST http://localhost:5000/api/rescan/azure-devops` | Opens new tab with raw JSON |
+| Compute Service Metrics | stat | `POST http://localhost:5000/api/compute/service-metrics` | Opens new tab with raw JSON |
+| API Health Check | stat | `GET http://localhost:5000/health` | Opens new tab with raw JSON |
+| Celery Monitor (Flower) | stat | `http://localhost:5555` | External link — fine as-is |
+| Active Runs | stat | (read-only metric) | Observability — keep in Grafana |
+| Latest Run Progress | stat | (read-only metric) | Observability — keep in Grafana |
+| Auth Failures (24h) | stat | (read-only metric) | Observability — keep in Grafana |
+| Recent Runs | table | (read-only) | Observability — keep in Grafana |
+| Stale Repositories (7+ days) | table | (read-only) | Observability — keep in Grafana |
+| Never Scanned | table | (read-only) | Observability — keep in Grafana |
+| Recent Repository Activity (with Errors) | table | (read-only) | Observability — keep in Grafana |
+| Auth Errors by Platform (24h) | table | (read-only) | Observability — keep in Grafana |
+
+**Phase 1 implication**: 4 action panels move to React (rescan ×2, compute metrics, health check). 9 observability panels stay in Grafana. Theme C.1 says only "start analysis" is actively used today, so React MVP could ship with just the two rescan triggers + health check, deferring Compute Service Metrics and Repository List to a Phase 1b.

--- a/.ai/investigations/grafana-ui-shortcomings.md
+++ b/.ai/investigations/grafana-ui-shortcomings.md
@@ -1,8 +1,8 @@
 # Investigation: Grafana UI Shortcomings — Navigation, Relational Drill-down, and Tool Fit
 
-**Status**: RESOLVED 2026-05-03 — **Outcome 2 selected** (split admin from analytics; bespoke admin UI + tidied Grafana). Proceed with [Plan 024](../plans/024-bespoke-admin-and-navigation-ui.md).
+**Status**: RESOLVED 2026-05-03 — **Outcome 2 selected** (split admin from analytics; bespoke admin UI + tidied Grafana). Proceed with [Plan 025](../plans/025-bespoke-admin-and-navigation-ui.md).
 **Created**: 2026-05-01
-**Related plans**: `.ai/plans/023-grafana-home-dashboard-links.md` (home nav links — closed), `.ai/plans/024-bespoke-admin-and-navigation-ui.md` (approved React UI)
+**Related plans**: `.ai/plans/023-grafana-home-dashboard-links.md` (home nav links — closed), `.ai/plans/025-bespoke-admin-and-navigation-ui.md` (approved React UI)
 
 ---
 
@@ -143,19 +143,19 @@ Once Themes A–E have answers, map them to one of three outcomes. The investiga
 | **(2) Split: bespoke admin UI + tidied Grafana analytics** | Theme C surfaces real tool-fit pain (admin in Grafana feels wrong), Theme D says analytics is mostly fine, Theme E supports modest ongoing maintenance | ~1–2 weeks for admin MVP + the Outcome 1 work             | Reversible — admin UI can be deleted, Grafana stays |
 | **(3) Replace analytics tool too**                         | Theme D surfaces ceiling problems (queries Grafana can't express, interactions it can't render)                                                        | Multi-week migration to Metabase/Superset/bespoke         | Hard — dashboards are real assets                   |
 
-**Pre-investigation lean** (to be confirmed by answers): Outcome 2. Plan 024 is drafted on that assumption.
+**Pre-investigation lean** (to be confirmed by answers): Outcome 2. Plan 025 is drafted on that assumption.
 
 **Resolution (2026-05-03): Outcome 2 confirmed.**
 
 | Theme | Signal | Mapped to outcome |
 | --- | --- | --- |
-| A — Navigation | Wants consistent top-link bar; wants click-through from any data row to its target dashboard. No breadcrumbs needed. | Tidy Grafana (Phase 2/3 of Plan 024) |
-| B — Drill-down | Friction is "no navigation at all" rather than slow nav. Data is there, just unconfigured. All panels with a unique target should drill down. | Tidy Grafana (Phase 3 of Plan 024) |
-| C — Admin | Only "start analysis" is used today. Does NOT feel right in Grafana. New-tab JSON feedback is bad UX. | Out of Grafana (Phase 1 of Plan 024) |
+| A — Navigation | Wants consistent top-link bar; wants click-through from any data row to its target dashboard. No breadcrumbs needed. | Tidy Grafana (Phase 2/3 of Plan 025) |
+| B — Drill-down | Friction is "no navigation at all" rather than slow nav. Data is there, just unconfigured. All panels with a unique target should drill down. | Tidy Grafana (Phase 3 of Plan 025) |
+| C — Admin | Only "start analysis" is used today. Does NOT feel right in Grafana. New-tab JSON feedback is bad UX. | Out of Grafana (Phase 1 of Plan 025) |
 | D — Tool fit | Grafana fine for charts/alerts. No query ceiling. Diagnostics/details and panel clutter are the actual issues. | Keep Grafana for analytics |
 | E — Effort | Team + leadership audience. Tidy nav + missing data links would solve ~80% of pain. Happy to maintain a small React app. | Outcome 2 viable |
 
-**80/20 implication**: Phases 2 + 3 of Plan 024 (Grafana tidy, ~2–3 days) capture most of the value. Phase 1 (React MVP, ~1–2 weeks) addresses the remaining admin pain. Plan 024 has been re-sequenced accordingly. RESOLVED
+**80/20 implication**: Phases 2 + 3 of Plan 025 (Grafana tidy, ~2–3 days) capture most of the value. Phase 1 (React MVP, ~1–2 weeks) addresses the remaining admin pain. Plan 025 has been re-sequenced accordingly. RESOLVED
 
 ---
 
@@ -180,13 +180,13 @@ These three artefacts make Themes A, B, and C answerable from data instead of me
 
 ## Next step
 
-When the synthesis table is at least half filled in, decide between Outcomes 1, 2, 3. If Outcome 2 (the current lean), proceed with [Plan 024](../plans/024-bespoke-admin-and-navigation-ui.md). If Outcome 1, scope a smaller "Grafana navigation hardening" plan instead. If Outcome 3, this becomes a much larger conversation.
+When the synthesis table is at least half filled in, decide between Outcomes 1, 2, 3. If Outcome 2 (the current lean), proceed with [Plan 025](../plans/025-bespoke-admin-and-navigation-ui.md). If Outcome 1, scope a smaller "Grafana navigation hardening" plan instead. If Outcome 3, this becomes a much larger conversation.
 
 ---
 
 ## Risks of skipping this investigation
 
-- Building Plan 024's React UI without confirming Theme C means we might over-build (rebuilding things Grafana actually does well) or under-build (missing the actual workflows that motivate the rebuild).
+- Building Plan 025's React UI without confirming Theme C means we might over-build (rebuilding things Grafana actually does well) or under-build (missing the actual workflows that motivate the rebuild).
 - Tidying Grafana without confirming Theme D means we may sink time into a tool that has a ceiling we haven't acknowledged.
 - 30–60 min of structured Q&A here probably saves a week of misdirected work.
 
@@ -194,7 +194,7 @@ When the synthesis table is at least half filled in, decide between Outcomes 1, 
 
 ## Audit findings (2026-05-03)
 
-These three audits make Phases 2 and 3 of Plan 024 mechanical to execute. Snapshot from `main` at the time of investigation closure.
+These three audits make Phases 2 and 3 of Plan 025 mechanical to execute. Snapshot from `main` at the time of investigation closure.
 
 ### 1. Top-link audit
 

--- a/.ai/plans/020-property-based-live-api-observability.md
+++ b/.ai/plans/020-property-based-live-api-observability.md
@@ -310,6 +310,8 @@ New file `dashboards/extraction-health.json`. Panels:
 
 Alert rule: fire if any invariant gauge is non-zero for more than 1 hour. Route to the same channel as existing extraction alerts.
 
+**Top-link bar (when Plan 024 has landed)**: copy the canonical 6-entry `links[]` array from any other `dashboards/*.json` (e.g. `security-dashboard.json`) so the new dashboard inherits the uniform top-link bar from Plan 024 Phase 2. Do not invent a new bar shape. If Plan 024 has not yet shipped, omit `links[]` and Phase 2 will add it during the sweep.
+
 #### 3.5 Documentation
 
 Short note in `docs/03-operations/extraction-health-monitoring.md`:

--- a/.ai/plans/020-property-based-live-api-observability.md
+++ b/.ai/plans/020-property-based-live-api-observability.md
@@ -310,7 +310,7 @@ New file `dashboards/extraction-health.json`. Panels:
 
 Alert rule: fire if any invariant gauge is non-zero for more than 1 hour. Route to the same channel as existing extraction alerts.
 
-**Top-link bar (when Plan 024 has landed)**: copy the canonical 6-entry `links[]` array from any other `dashboards/*.json` (e.g. `security-dashboard.json`) so the new dashboard inherits the uniform top-link bar from Plan 024 Phase 2. Do not invent a new bar shape. If Plan 024 has not yet shipped, omit `links[]` and Phase 2 will add it during the sweep.
+**Top-link bar (when Plan 025 has landed)**: copy the canonical 6-entry `links[]` array from any other `dashboards/*.json` (e.g. `security-dashboard.json`) so the new dashboard inherits the uniform top-link bar from Plan 025 Phase 2. Do not invent a new bar shape. If Plan 025 has not yet shipped, omit `links[]` and Phase 2 will add it during the sweep.
 
 #### 3.5 Documentation
 

--- a/.ai/plans/022-tech-radar-publication-plan.md
+++ b/.ai/plans/022-tech-radar-publication-plan.md
@@ -366,11 +366,11 @@ def export_radar():
     """
 ```
 
-### Viewer UI — superseded by Plan 024
+### Viewer UI — superseded by Plan 025
 
-A standalone `src/api/radar_viewer.html` is **no longer planned**. With Plan 024 introducing a React app at `web/admin-ui/`, the radar viewer becomes a route in that app (Plan 024 Phase 1c, deferred). It consumes the `/api/radar`, `/api/radar/history`, and `/api/radar/export` endpoints defined above — all backend work in this plan is unchanged.
+A standalone `src/api/radar_viewer.html` is **no longer planned**. With Plan 025 introducing a React app at `web/admin-ui/`, the radar viewer becomes a route in that app (Plan 025 Phase 1c, deferred). It consumes the `/api/radar`, `/api/radar/history`, and `/api/radar/export` endpoints defined above — all backend work in this plan is unchanged.
 
-If Plan 024's React app is dropped or the radar must ship before Phase 1c, fall back to: external viewer (`https://radar.thoughtworks.com`) consuming `/api/radar` JSON.
+If Plan 025's React app is dropped or the radar must ship before Phase 1c, fall back to: external viewer (`https://radar.thoughtworks.com`) consuming `/api/radar` JSON.
 
 ---
 
@@ -446,7 +446,7 @@ def test_high_cve_exposure_not_adopt():
 | ❌ TODO | Create | `tests/contract/database/test_radar_categorization.py` |
 | ❌ TODO | Create | `tests/contract/api/test_radar_endpoints.py` |
 | ❌ TODO | Create | `tests/unit/test_radar_categorizer.py` |
-| ❌ Removed | — | ~~`src/api/radar_viewer.html`~~ — replaced by Plan 024 Phase 1c (React route) |
+| ❌ Removed | — | ~~`src/api/radar_viewer.html`~~ — replaced by Plan 025 Phase 1c (React route) |
 | ⚠️ Optional | Create | `.github/workflows/publish-radar.yml` (scheduled publication) |
 
 ---

--- a/.ai/plans/022-tech-radar-publication-plan.md
+++ b/.ai/plans/022-tech-radar-publication-plan.md
@@ -366,13 +366,11 @@ def export_radar():
     """
 ```
 
-### File: `src/api/radar_viewer.html` (optional)
+### Viewer UI — superseded by Plan 024
 
-Simple HTML wrapper linking to TW Radar viewer:
+A standalone `src/api/radar_viewer.html` is **no longer planned**. With Plan 024 introducing a React app at `web/admin-ui/`, the radar viewer becomes a route in that app (Plan 024 Phase 1c, deferred). It consumes the `/api/radar`, `/api/radar/history`, and `/api/radar/export` endpoints defined above — all backend work in this plan is unchanged.
 
-```html
-<!-- Embedded viewer or iframe to https://radar.thoughtworks.com/?sheetId=... -->
-```
+If Plan 024's React app is dropped or the radar must ship before Phase 1c, fall back to: external viewer (`https://radar.thoughtworks.com`) consuming `/api/radar` JSON.
 
 ---
 
@@ -448,7 +446,7 @@ def test_high_cve_exposure_not_adopt():
 | ❌ TODO | Create | `tests/contract/database/test_radar_categorization.py` |
 | ❌ TODO | Create | `tests/contract/api/test_radar_endpoints.py` |
 | ❌ TODO | Create | `tests/unit/test_radar_categorizer.py` |
-| ⚠️ Optional | Create | `src/api/radar_viewer.html` (link to external viewer) |
+| ❌ Removed | — | ~~`src/api/radar_viewer.html`~~ — replaced by Plan 024 Phase 1c (React route) |
 | ⚠️ Optional | Create | `.github/workflows/publish-radar.yml` (scheduled publication) |
 
 ---

--- a/.ai/plans/024-bespoke-admin-and-navigation-ui.md
+++ b/.ai/plans/024-bespoke-admin-and-navigation-ui.md
@@ -50,13 +50,14 @@ This plan splits the concerns:
 **Phase 2 — Cross-dashboard nav tidy (Grafana-side, no React) — RUN FIRST:**
 
 - Uniform top-link bar across 11 of 12 dashboards in `dashboards/*.json` (`dashboard-home.json` keeps no bar — it IS Home). Six entries in this fixed order: **Home, Repos, Security, Technology, Admin, Admin UI**.
-  - `Home` → `/d/dashboard-home`
+  - `Home` → `/d/dashboard-home` (type: `dashboards` or `link` with relative URL — see canonical example below)
   - `Repos` → `/d/repo-overview`
   - `Security` → `/d/security-dashboard`
   - `Technology` → `/d/technology-landscape`
   - `Admin` → `/d/admin-dashboard` (Grafana admin observability)
-  - `Admin UI` → `/admin/` (new React UI — link added in Phase 2 even though the UI itself isn't built until Phase 1; renders as a 404 in the meantime, which is acceptable for an internal tool)
-- All entries use `targetBlank=false` so navigation stays in-tab.
+  - `Admin UI` → `http://localhost:8080/` with `targetBlank: true` (new React UI — Phase 1 will serve it on `:8080`. Until Phase 1 ships, this link 404s; opening in a new tab keeps the dead-link impact minimal. **All other entries use `targetBlank: false`.**)
+- The links array **fully replaces** any existing `links[]` in each dashboard JSON — do not append.
+- Canonical existing example: `security-dashboard.json` already has 6 working internal links — copy that link object shape (`type`, `icon`, `tags`, `targetBlank`, `url`, `title`) and just swap the entry list.
 - Replaces the 7 distinct shapes catalogued in the top-link audit (investigation, audit #1).
 
 **Phase 3 — Relational drill-down completeness (Grafana-side, no React) — RUN SECOND:**

--- a/.ai/plans/024-bespoke-admin-and-navigation-ui.md
+++ b/.ai/plans/024-bespoke-admin-and-navigation-ui.md
@@ -1,0 +1,294 @@
+# Plan 024: Bespoke Web UI for Admin & Cross-Dashboard Navigation
+
+## Status: APPROVED 2026-05-03
+
+**Implements**: A small React frontend that owns admin/operational workflows and coexists with Grafana — Grafana remains the home for analytics charts and the primary "Home" landing.
+
+**Predicate met**: [Investigation grafana-ui-shortcomings](../investigations/grafana-ui-shortcomings.md) closed 2026-05-03 with Outcome 2 selected. The audits at the bottom of that document drive Phases 2 and 3 of this plan.
+
+---
+
+## Decisions (recorded 2026-05-03)
+
+Answered open questions, locked in for execution:
+
+1. **Outcome 2 confirmed** — investigation resolved; this plan is approved.
+2. **Framework**: React + Vite + TypeScript.
+3. **Auth**: ship without auth (matches the current Flask API). Auth is a future plan touching both layers.
+4. **Location**: `web/admin-ui/`.
+5. **Coexistence**: React UI **coexists** with `dashboards/dashboard-home.json` — neither replaces the other. The Grafana top-link bar's `Home` entry continues to point to the Grafana home dashboard. The React UI gets its own `Admin UI` top-link slot in the Grafana bar (option (a) — see Phase 2 below).
+
+### Phase ordering (revised based on Theme E.2)
+
+Theme E.2 of the investigation: tidying nav + adding missing data links solves "80% of the pain". So phases now run in this order to capture value fastest:
+
+1. **Phase 2 first** — uniform Grafana top-link bar (~1 day, mechanical, coding-agent ready).
+2. **Phase 3 second** — missing data links (~1–2 days, ~10 specific edits enumerated in the investigation's drill-down audit).
+3. **Phase 1 third** — React admin UI (~1–2 weeks). Scope tightened: Theme C.1 says "start analysis" is the only admin action used today, so Phase 1a ships with rescan triggers + health, deferring Repository List and Compute Service Metrics to Phase 1b.
+
+---
+
+## Problem
+
+Two pains drove this plan (full breakdown in the investigation):
+
+1. **Grafana is the wrong tool for admin/CRUD.** `admin-dashboard.json` triggers rescans by rendering a Grafana stat panel whose `links[]` entry POSTs to `http://localhost:5000/api/rescan/github` — clicking it opens a new browser tab showing JSON. There's no in-place feedback, no progress, no per-repo controls, no service/team mapping editor.
+2. **Cross-dashboard navigation is uneven.** Top-link bars are inconsistently populated (1–8 entries per dashboard). There's no breadcrumb. Returning Home, jumping to a sibling, or following a relational link from "repo X has vulnerability Y" to the repo deep-dive only sometimes works.
+
+This plan splits the concerns:
+
+- **Admin workflows leave Grafana** and live in a small React UI that calls the existing Flask API.
+- **Analytics stays in Grafana** (those dashboards are good at what they do); this plan only adds the missing data links and a uniform top-link bar so cross-dashboard nav stops being a paper cut.
+- The new React UI doubles as the **navigation hub**: a single landing page that links into Grafana dashboards by topic and exposes admin actions from one place.
+
+---
+
+## Scope
+
+### In scope
+
+**Phase 2 — Cross-dashboard nav tidy (Grafana-side, no React) — RUN FIRST:**
+
+- Uniform top-link bar across 11 of 12 dashboards in `dashboards/*.json` (`dashboard-home.json` keeps no bar — it IS Home). Six entries in this fixed order: **Home, Repos, Security, Technology, Admin, Admin UI**.
+  - `Home` → `/d/dashboard-home`
+  - `Repos` → `/d/repo-overview`
+  - `Security` → `/d/security-dashboard`
+  - `Technology` → `/d/technology-landscape`
+  - `Admin` → `/d/admin-dashboard` (Grafana admin observability)
+  - `Admin UI` → `/admin/` (new React UI — link added in Phase 2 even though the UI itself isn't built until Phase 1; renders as a 404 in the meantime, which is acceptable for an internal tool)
+- All entries use `targetBlank=false` so navigation stays in-tab.
+- Replaces the 7 distinct shapes catalogued in the top-link audit (investigation, audit #1).
+
+**Phase 3 — Relational drill-down completeness (Grafana-side, no React) — RUN SECOND:**
+
+For each gap in the investigation's drill-down audit (audit #2), add a `fieldConfig.overrides[]` entry pointing to the natural target dashboard. The high-value gaps:
+
+- `security-dashboard.json` "Top Vulnerable Dependencies" → `library-detail-deep-dive` by package name
+- `dependency-vulnerability-portfolio.json` "Top 20 Vulnerable Packages" → `library-detail-deep-dive`
+- `dependency-vulnerability-portfolio.json` "Packages Reaching EOL Within 90 Days" → `library-detail-deep-dive`
+- `dependency-vulnerability-portfolio.json` "Package Usage by Team" → `library-detail-deep-dive` (and `team-overview` if a team column exists)
+- `library-detail-deep-dive.json` "Repositories Using $package_name" → `repo-deep-dive` **(highest-value gap — closes the user's main complaint)**
+- `technology-landscape.json` "EOL Technologies with Affected Repo Count" → `repo-deep-dive` (filtered)
+- `technology-landscape.json` "Repository Stack (by source)" → `repo-deep-dive`
+- `repository-deep-dive.json` "Vulnerability Details" → `library-detail-deep-dive`
+- `repository-deep-dive.json` "Technologies (Detected Stack)" → `technology-landscape` (filtered)
+- `repository-deep-dive.json` "Open Pull Requests" → `pull-requests`
+- `team-overview.json` "Team Performance Summary" → `repo-overview` (filtered by team)
+- `service-overview.json` "Technology Stack by Service" → `technology-landscape` (filtered)
+
+Skipped (no obvious target or external link): `repository-deep-dive` Branch Details / Repository Summary / Recent Commits, `library-detail-deep-dive` Health Status / CVE Details.
+
+**Phase 1 — Admin UI MVP (~1–2 weeks) — RUN THIRD:**
+
+- New React + Vite + TypeScript app in `web/admin-ui/`.
+- Talks to existing Flask API at `http://localhost:5000`. **No new backend endpoints required.**
+- Auth: none (matches the current Flask API).
+
+**Phase 1a (must-ship, narrowed to Theme C.1 actual usage):**
+
+- **Home** — landing page with tiles linking out to each Grafana dashboard.
+- **Extraction Control** — trigger GitHub rescan and Azure DevOps rescan. In-page success/failure feedback (toast) replacing the current "open JSON in a new tab" UX.
+- **System Health** — render `/health` output; link out to Flower (`http://localhost:5555`) and to the Grafana admin observability dashboard.
+
+**Phase 1b (deferred — only if Phase 1a's value is confirmed):**
+
+- **Compute Service Metrics** trigger on the Extraction Control page.
+- **Repository List** — paginated/filterable view of `/api/repositories` with per-row Rescan/Remove buttons.
+
+### Out of scope
+
+- Rebuilding any analytics dashboard in React. Charts stay in Grafana. If the investigation surfaces queries Grafana can't express, that's a separate plan.
+- Authentication/authorisation. The current API is unauthenticated; the UI will be too. Adding auth is a future plan touching both layers.
+- Editing service ↔ repository mappings. Tempting, but adds a write-path that doesn't exist on the API today. Punt to a follow-up plan if Theme C surfaces it as a real need.
+- Server-side rendering, mobile-first design, i18n, dark/light themes beyond defaults.
+- Deploying behind a real domain or TLS — for MVP, the UI is served on `localhost` like everything else.
+
+---
+
+## API surface used (read-only confirmation)
+
+All endpoints already exist; this is a contract list, not new work.
+
+| Endpoint                                  | Used by            |
+| ----------------------------------------- | ------------------ |
+| `POST /api/rescan/github`                 | Extraction Control |
+| `POST /api/rescan/azure-devops`           | Extraction Control |
+| `POST /api/rescan/repository/<repo_id>`   | Repository List    |
+| `DELETE /api/rescan/repository/<repo_id>` | Repository List    |
+| `GET /api/repositories`                   | Repository List    |
+| `POST /api/compute/service-metrics`       | Extraction Control |
+| `GET /health`                             | System Health      |
+
+If any of these grow query parameters to support the UI better (e.g. `/api/repositories?stale=true`), that's a small follow-up addition, not blocking.
+
+---
+
+## Architecture
+
+### Where it lives
+
+```
+web/
+  admin-ui/
+    src/
+      pages/        ← Home, Extraction, Repos, Health
+      components/   ← Shared UI primitives
+      api/          ← Typed wrappers around the Flask endpoints
+    public/
+    package.json
+    vite.config.ts
+    tsconfig.json
+    Dockerfile      ← multi-stage: Node build → nginx static serve
+```
+
+### How it talks to the backend
+
+- Dev: Vite dev server on `:5173`, proxies `/api` and `/health` to `http://localhost:5000`. CORS not needed because of the proxy.
+- Prod (in-stack): nginx serving the static build on `:8080`, with `/api` and `/health` reverse-proxied to the Flask container. Added as a new service `admin-ui` to `docker-compose.yml`.
+
+### Architecture-Guardian alignment
+
+- The new code is a frontend. It does not import from `src/extractors/`, `src/analyzers/`, `src/database/`, or `src/workflows/`. It only consumes HTTP endpoints exposed by `src/api/`.
+- No changes to extractor/analyzer/database/workflow boundaries. (Principle 2 satisfied — boundaries unchanged.)
+- No changes to the test architecture in `tests/contract/` or `tests/implementation/`. New frontend tests live alongside the frontend code (`web/admin-ui/src/**/*.test.tsx`) and run independently of the Python suite. (Principle 1 satisfied — Python contract tests untouched.)
+
+### Tech-stack rationale
+
+| Choice                           | Why                                                                                               | What we considered and rejected                                                               |
+| -------------------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| React + Vite + TypeScript        | Standard, fast dev loop, large hire-pool, types catch most refactor regressions                   | Next.js (overkill — no SSR needed); Svelte (smaller community for a long-lived internal tool) |
+| TanStack Query for data fetching | Built-in caching, refetch-on-focus, mutation feedback — good fit for "trigger rescan, show toast" | Plain `fetch` (would re-implement caching by hand); Redux Toolkit Query (heavier than needed) |
+| Tailwind for styling             | Lets us ship fast without a design system                                                         | A real component library (MUI, Chakra) — too heavyweight for a small internal tool            |
+| Vitest + React Testing Library   | Standard for Vite projects                                                                        | Jest (works fine but Vitest integrates with Vite config natively)                             |
+
+If the user has a strong preference for Vue/Svelte/HTMX, swap before implementation — none of the structural decisions in this plan depend on React specifically.
+
+---
+
+## Phased delivery
+
+Phases ship in order — Phase 2 first (highest value-per-day), then 3, then 1. Phases 2 and 3 are coding-agent ready.
+
+### Phase 2 — Uniform Grafana top-link bar (~1 day) — FIRST
+
+Edit each `dashboards/*.json` (except `dashboard-home.json`) to have the same 6-entry `links[]` array as specified in the Scope section. Mechanical change.
+
+### Phase 3 — Missing drill-downs (~1–2 days) — SECOND
+
+For each gap enumerated in the Scope section, add a `fieldConfig.overrides[]` entry on the relevant table panel. Each gap is a small isolated JSON edit. Use the Plan 021 pattern (existing data link on `security-dashboard.json` "Repository Security Overview") as the canonical example.
+
+### Phase 1 — Admin UI MVP (~1–2 weeks) — THIRD
+
+1. Scaffold `web/admin-ui/` with Vite + React + TS + Tailwind + TanStack Query + Vitest.
+2. Implement the API client wrappers (typed) for the Phase 1a endpoints (3 endpoints: github rescan, azure-devops rescan, health).
+3. Implement Home, Extraction Control, System Health pages.
+4. Add `Dockerfile`, `nginx.conf`, and `admin-ui` service to `docker-compose.yml`.
+5. Add a job to `.github/workflows/` (or extend existing) to: install, build, type-check, run unit tests on PRs touching `web/admin-ui/**`.
+6. Phase 1b (Compute Metrics trigger + Repository List page) added in a follow-up PR if Phase 1a's value is confirmed.
+
+---
+
+## Acceptance criteria
+
+### Phase 2
+
+- [ ] Every `dashboards/*.json` except `dashboard-home.json` has identical 6-entry `links[]` array (Home / Repos / Security / Technology / Admin / Admin UI) in that order.
+- [ ] `dashboard-home.json` retains no top-link bar.
+- [ ] All entries use `targetBlank=false`.
+- [ ] Manual click-through: from each dashboard, each top-link entry lands on the right destination (Admin UI link 404s until Phase 1 ships — acceptable).
+- [ ] JSON sanity per Plan 023 pattern: `python -c "import json; json.load(open('dashboards/<file>.json'))"` exits 0 for each file.
+
+### Phase 3
+
+- [ ] Every gap listed in the Scope section's Phase 3 list has a working data link.
+- [ ] Skipped panels (Branch Details, Repository Summary, Recent Commits, Health Status, CVE Details) are documented inline as deliberate skips.
+- [ ] Manual click-through: pick one gap-fix per dashboard, confirm the data link opens the right target with the right filter applied.
+
+### Phase 1a (must-ship MVP)
+
+- [ ] `docker compose up admin-ui` serves the UI at a known port (e.g. `:8080`).
+- [ ] Home page renders tiles linking to each existing Grafana dashboard.
+- [ ] Clicking "Trigger GitHub rescan" calls `POST /api/rescan/github`, shows an in-page success toast with the returned `task_id`, and does **not** open a new browser tab.
+- [ ] Same for Azure DevOps rescan.
+- [ ] System Health page shows `/health` output and a working "Open Flower" link.
+- [ ] `npm run typecheck` and `npm run test` exit 0 in `web/admin-ui/`.
+- [ ] CI runs frontend lint/typecheck/test on PRs touching `web/admin-ui/**`.
+- [ ] No changes to `src/extractors/**`, `src/analyzers/**`, `src/database/**`, `src/workflows/**`. (Architecture boundary check.)
+- [ ] Python test suite (`bash scripts/run-tests-docker.sh`) still passes — this plan adds no Python code, but verify nothing was broken by Docker Compose changes.
+
+### Phase 1b (follow-up, optional)
+
+- [ ] Compute Service Metrics trigger added to Extraction Control with toast feedback.
+- [ ] Repository List page renders rows from `/api/repositories`, supports filter-by-name, and per-row Rescan/Remove buttons work and show feedback.
+
+---
+
+## Test plan
+
+### Frontend (Phase 1)
+
+- Unit-test each API client wrapper against a mocked `fetch` — covers shape of request and parsing of response.
+- Component-test each page with TanStack Query in test mode and the API client mocked — covers happy path + error path (e.g. rescan API returns 500).
+- Manual smoke-test in the browser: every button performs the right network call (verified via DevTools), every dashboard tile lands on the right `/d/...`.
+
+### Grafana (Phases 2–3)
+
+- JSON sanity per Plan 023's pattern: `python -c "import json; json.load(open('dashboards/<file>.json'))"`.
+- `jq` checks that all `links[]` arrays match the canonical 5-entry shape.
+- Visual check: stack up, click every link from every dashboard.
+
+### Cross-cutting
+
+- `bash scripts/run-tests-docker.sh` still green (no Python changes expected; this is a regression check on the Compose changes).
+
+---
+
+## Risks
+
+| Risk                                                                                     | Probability | Mitigation                                                                                                                                                                      |
+| ---------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Phase 2 dead-link `Admin UI` 404s confuse users between Phase 2 ship and Phase 1 ship    | Low         | Internal-only tool, small audience. If Phase 1 slips, change `Admin UI` link target to `/d/admin-dashboard` as a placeholder.                                                   |
+| API endpoints prove insufficient (e.g. `/api/repositories` doesn't expose enough fields) | Medium      | Each gap is a small additive endpoint change in `src/api/rescan.py`. Defer until Phase 1b surfaces the specific need.                                                           |
+| Maintenance burden of a second codebase outweighs benefit                                | Medium      | Phase 1a is deliberately tiny (3 pages, no auth, no fancy state). Phase 1b only ships if 1a's value is real.                                                                    |
+| Auth becomes urgent later                                                                | Medium      | Plan now: when the Flask API gets auth, add a login page and an `Authorization` header to the API client. Both are well-trodden patterns; not a blocker today.                  |
+| nginx + reverse proxy complexity in Compose                                              | Low         | Pattern is standard; many examples online. Worst case, serve via Vite preview in dev and skip nginx until prod really matters.                                                  |
+
+---
+
+## File manifest (Phase 1)
+
+```
+web/admin-ui/
+  Dockerfile                         (new)
+  nginx.conf                         (new)
+  package.json                       (new)
+  tsconfig.json                      (new)
+  vite.config.ts                     (new)
+  tailwind.config.ts                 (new)
+  index.html                         (new)
+  src/
+    main.tsx                         (new)
+    App.tsx                          (new)
+    pages/
+      HomePage.tsx                   (new)
+      ExtractionPage.tsx             (new)
+      RepositoriesPage.tsx           (new)
+      HealthPage.tsx                 (new)
+    components/
+      Layout.tsx                     (new)
+      Toast.tsx                      (new)
+      ApiButton.tsx                  (new)
+    api/
+      client.ts                      (new)
+      types.ts                       (new)
+docker-compose.yml                   (modified — add admin-ui service)
+.github/workflows/frontend.yml       (new — or extend tests.yml)
+```
+
+**Estimated effort**: Phase 1 ~5–10 working days for one developer; Phases 2–3 ~2–3 days combined and parallelisable.
+
+---
+
+## Open questions
+
+All previously open questions resolved 2026-05-03 — see the **Decisions** section near the top of this document.

--- a/.ai/plans/024-bespoke-admin-and-navigation-ui.md
+++ b/.ai/plans/024-bespoke-admin-and-navigation-ui.md
@@ -96,6 +96,19 @@ Skipped (no obvious target or external link): `repository-deep-dive` Branch Deta
 - **Compute Service Metrics** trigger on the Extraction Control page.
 - **Repository List** — paginated/filterable view of `/api/repositories` with per-row Rescan/Remove buttons.
 
+**Phase 1c (deferred — Tech Radar viewer, depends on Plan 022 shipping):**
+
+- React route at `/radar` rendering the Thoughtworks-format JSON returned by `GET /api/radar` (Plan 022 Part C).
+- React route at `/radar/history` rendering the timeline from `GET /api/radar/history` as a sortable table.
+- Replaces the now-removed `src/api/radar_viewer.html` from Plan 022. Plan 022's backend is unchanged and ships independently of this phase.
+- Rationale: Tech Radar is a leadership-facing artifact (Theme E.1 audience). A React route is much cleaner than an iframe to thoughtworks.com or a static HTML wrapper, and is exactly the kind of high-visibility surface that justifies the React investment beyond admin chores.
+
+**Phase 1d (deferred — Library detail page, depends on Plan 021 endpoints):**
+
+- React route at `/library/:ecosystem/:name` consuming `GET /api/packages/library/<name>/<ecosystem>` (Plan 021 Part C).
+- Renders metadata + CVE list + adoption timeline + per-repo usage in a layout the Grafana `library-detail-deep-dive.json` dashboard struggles with (Theme D.1: "panels can feel cluttered and have scrollbars to find links").
+- Coexists with the Grafana dashboard — both stay; data links from Phase 3 still point to the Grafana version. The Grafana home dashboard could optionally add a "Library Browser" tile pointing to the React route once shipped.
+
 ### Out of scope
 
 - Rebuilding any analytics dashboard in React. Charts stay in Grafana. If the investigation surfaces queries Grafana can't express, that's a separate plan.

--- a/.ai/plans/025-bespoke-admin-and-navigation-ui.md
+++ b/.ai/plans/025-bespoke-admin-and-navigation-ui.md
@@ -1,4 +1,6 @@
-# Plan 024: Bespoke Web UI for Admin & Cross-Dashboard Navigation
+# Plan 025: Bespoke Web UI for Admin & Cross-Dashboard Navigation
+
+> **Renumber note (2026-05-03)**: Originally drafted as Plan 024. Renumbered to 025 because PR #83 (open at drafting time) reserved Plan 024 for "auth error taxonomy and view consistency". Phase numbering inside this document is unchanged.
 
 ## Status: APPROVED 2026-05-03
 

--- a/.ai/prompts/README.md
+++ b/.ai/prompts/README.md
@@ -1,0 +1,24 @@
+# Coding-agent prompts
+
+Ready-to-paste prompts for delegating work to GitHub Copilot agents (or equivalents). Each prompt is self-contained — assume the agent has not seen any prior conversation.
+
+## Wave 1 (parallel — disjoint files, no merge conflicts)
+
+| Prompt | Plan | Description |
+|---|---|---|
+| [wave-1a-grafana-uniform-top-link-bar.md](wave-1a-grafana-uniform-top-link-bar.md) | Plan 025 Phase 2 | Uniform 6-entry `links[]` across 11 dashboards |
+| [wave-1b-tech-radar-schema-and-categorizer.md](wave-1b-tech-radar-schema-and-categorizer.md) | Plan 022 Track A | Radar schema migration + categorization engine |
+| [wave-1c-property-based-identity-tests.md](wave-1c-property-based-identity-tests.md) | Plan 020 Component 1 | Hypothesis-based property tests for `get_or_create_contributor` |
+| [wave-1d-extraction-health-observability.md](wave-1d-extraction-health-observability.md) | Plan 020 Component 3 | `extraction_health.py` + Prometheus emission + new dashboard |
+
+## Wave 2 (after Wave 1 PRs merged)
+
+Drafted on demand. Likely:
+
+- Plan 025 Phase 3 (drill-down data links) — sequenced after Wave 1A to avoid `dashboards/*.json` merge conflicts
+- Plan 022 Track B (radar workflow) — depends on Wave 1B's schema
+- Plan 020 Component 2 (live-API nightly) — depends on canary secrets being provisioned manually first
+
+## Why this folder exists
+
+Previous Copilot agent rounds on this project have ended with the agent declaring done while CI was red, costing 2+ feedback rounds per task. Every prompt here includes a non-negotiable acceptance block requiring `gh pr checks --watch` and root-cause fixing on red. Reuse the block when drafting new prompts.

--- a/.ai/prompts/wave-1a-grafana-uniform-top-link-bar.md
+++ b/.ai/prompts/wave-1a-grafana-uniform-top-link-bar.md
@@ -1,0 +1,174 @@
+# Wave 1A — Plan 025 Phase 2: Uniform Grafana top-link bar
+
+## Goal
+
+Replace the inconsistent top-link bar across 11 Grafana dashboard JSON files with a single canonical 6-entry bar. Today there are 7 distinct shapes (1–6 entries each), and `technology-landscape.json` has no bar at all. After this PR, every dashboard except `dashboard-home.json` should render the same bar in the same order.
+
+## Source plan
+
+`.ai/plans/025-bespoke-admin-and-navigation-ui.md`, "Phase 2 — Uniform Grafana top-link bar". Read the **Scope → In scope → Phase 2** section before starting.
+
+## Files to modify
+
+All of `dashboards/*.json` **except** `dashboard-home.json`. Eleven files:
+
+```
+dashboards/admin-dashboard.json
+dashboards/contributor-analytics.json
+dashboards/dependency-vulnerability-portfolio.json
+dashboards/library-detail-deep-dive.json
+dashboards/pull-requests.json
+dashboards/repository-deep-dive.json
+dashboards/repository-overview.json
+dashboards/security-dashboard.json
+dashboards/service-overview.json
+dashboards/team-overview.json
+dashboards/technology-landscape.json
+```
+
+`dashboards/dashboard-home.json` keeps no top-link bar — it IS Home.
+
+## What to do
+
+For each of the 11 files: **fully replace** the `links` array at the top level of the JSON with the following 6-entry array. Do **not** append — replace.
+
+```json
+"links": [
+  {
+    "asDropdown": false,
+    "icon": "home",
+    "includeVars": false,
+    "keepTime": true,
+    "tags": [],
+    "targetBlank": false,
+    "title": "Home",
+    "type": "link",
+    "url": "/d/dashboard-home"
+  },
+  {
+    "asDropdown": false,
+    "icon": "dashboard",
+    "includeVars": false,
+    "keepTime": true,
+    "tags": [],
+    "targetBlank": false,
+    "title": "Repos",
+    "type": "link",
+    "url": "/d/repo-overview"
+  },
+  {
+    "asDropdown": false,
+    "icon": "dashboard",
+    "includeVars": false,
+    "keepTime": true,
+    "tags": [],
+    "targetBlank": false,
+    "title": "Security",
+    "type": "link",
+    "url": "/d/security-dashboard"
+  },
+  {
+    "asDropdown": false,
+    "icon": "dashboard",
+    "includeVars": false,
+    "keepTime": true,
+    "tags": [],
+    "targetBlank": false,
+    "title": "Technology",
+    "type": "link",
+    "url": "/d/technology-landscape"
+  },
+  {
+    "asDropdown": false,
+    "icon": "cog",
+    "includeVars": false,
+    "keepTime": true,
+    "tags": [],
+    "targetBlank": false,
+    "title": "Admin",
+    "type": "link",
+    "url": "/d/admin-dashboard"
+  },
+  {
+    "asDropdown": false,
+    "icon": "external link",
+    "includeVars": false,
+    "keepTime": false,
+    "tags": [],
+    "targetBlank": true,
+    "title": "Admin UI",
+    "type": "link",
+    "url": "http://localhost:8080/"
+  }
+]
+```
+
+Notes:
+- The `Admin UI` entry is the **only one** with `targetBlank: true`. It points to a React app that does not exist yet (Plan 025 Phase 1) — opening in a new tab keeps the dead-link impact minimal until Phase 1 ships.
+- Use 2-space indentation to match the existing dashboard JSON files. Run a JSON formatter / linter if unsure — the files in `dashboards/` are pretty-printed.
+
+## What NOT to do
+
+- Do **not** touch `dashboards/dashboard-home.json`. It deliberately has no top-link bar.
+- Do **not** modify any other top-level dashboard property (`title`, `uid`, `panels`, `templating`, `tags`, `time`, etc.).
+- Do **not** modify panels, queries, or data links inside panels — that's Wave 2 / Plan 025 Phase 3.
+- Do **not** rename files, change `uid` values, or restructure the JSON.
+- Do **not** change Grafana schema version, datasource references, or anything not in the `links` array.
+
+## Acceptance criteria
+
+- [ ] 11 files modified, all with identical `links[]` arrays in the same order.
+- [ ] `dashboards/dashboard-home.json` is unchanged.
+- [ ] No other top-level fields modified in any file.
+- [ ] Each modified file passes JSON sanity:
+      ```bash
+      for f in dashboards/*.json; do
+        python -c "import json; json.load(open('$f'))" || echo "FAIL: $f"
+      done
+      ```
+- [ ] `git diff` shows ONLY `links[]` array changes (no formatting churn elsewhere). Use a JSON-aware diff if possible.
+
+## Test plan
+
+This change is config-only (no Python). The existing test suite should pass unchanged:
+
+```bash
+bash scripts/run-tests-docker.sh
+```
+
+If it doesn't, you've changed something you shouldn't have — `git diff` and revert.
+
+## Branch and PR conventions
+
+- Branch from `main`: `git checkout -b plan-025/phase-2-uniform-top-link-bar`
+- PR title: `feat(plan-025): uniform 6-entry top-link bar across Grafana dashboards`
+- PR body must include: link to `.ai/plans/025-bespoke-admin-and-navigation-ui.md`, brief summary of which files changed, note that `Admin UI` link is intentionally dead until Plan 025 Phase 1 ships.
+
+## ACCEPTANCE — DO NOT STOP UNTIL CI IS GREEN
+
+This is non-negotiable. Previous Copilot agents on this project have declared work done while CI was red, costing the user 2+ feedback rounds per task.
+
+1. After pushing your branch and opening the PR, run: `gh pr checks <PR#> --watch`
+2. If any required check fails:
+   1. `gh run view <run-id> --log-failed` to read the failure logs
+   2. Identify root cause; do **NOT** skip with `--no-verify` or disable tests to make CI pass
+   3. Fix the actual problem, commit, push
+   4. Repeat from step 1
+3. Required check for this repo: the `tests` workflow (`.github/workflows/tests.yml`). Informational checks (lint warnings, codecov) do not block.
+4. Only declare the task complete when:
+   - All required checks are green
+   - The PR has no merge conflicts
+   - You have posted a final comment on the PR linking to the green check run
+
+If you cannot get CI green after 3 attempts, **stop** and post a comment explaining what you tried and what's blocking. Do not declare the task complete with red CI.
+
+## Out of scope (defer to other waves / plans)
+
+- Adding data links to panels (Plan 025 Phase 3 — Wave 2)
+- React UI implementation (Plan 025 Phase 1 — Wave 3)
+- Any backend, schema, or workflow changes
+- Touching `dashboard-home.json`
+
+## Estimated size
+
+~1 day. Mechanical JSON edits; no logic.

--- a/.ai/prompts/wave-1b-tech-radar-schema-and-categorizer.md
+++ b/.ai/prompts/wave-1b-tech-radar-schema-and-categorizer.md
@@ -1,0 +1,102 @@
+# Wave 1B — Plan 022 Track A: Tech Radar schema and categorization engine
+
+## Goal
+
+Land the foundation for Plan 022 (Tech Radar Publication): three database tables, a Python categorization engine, its config file, and the contract + unit tests that prove the categorization rules work. **Do not** implement the workflow (Track B) or the API endpoints (Track C) — those are separate PRs.
+
+## Source plan
+
+`.ai/plans/022-tech-radar-publication-plan.md`. Read **Part A** (Schema), **Part B** (Categorization Engine), and **Part D** (Tests). Skip Part C (API) and the workflow file in Part B — out of scope here.
+
+## Files to create
+
+### Schema (Part A)
+
+- `database/migrations/018_tech_radar_schema.sql` — three new tables: `radar_publications`, `radar_blips`, `radar_blip_history`. Exact DDL is in Plan 022 Part A. Migration must be **idempotent** (use `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`) to match this project's migration conventions — see existing migrations like `database/migrations/017_*.sql` for the pattern.
+
+### Categorization engine (Part B)
+
+- `src/analyzers/radar_categorization.py` — defines:
+  - `Ring` enum: ADOPT, TRIAL, ASSESS, HOLD
+  - `Quadrant` enum: INFRASTRUCTURE, PLATFORMS, TOOLS, LANGUAGES (= "Languages & Frameworks")
+  - `RadarBlip` dataclass with the fields shown in Plan 022 Part B
+  - `RadarCategorizer` class with `categorize(package_name, ecosystem, metrics) -> RadarBlip` and the helper `_ring_from_adoption(repo_count, time_in_use_days) -> Ring`
+  - Loads rules from `radar_categorization_config.json` (see below)
+  - Categorization priority on conflicting signals: **EOL > CVE Exposure > Adoption Metrics** (Plan 022 Implementation Note 2)
+
+- `src/analyzers/radar_categorization_config.json` — exact JSON in Plan 022 Part B "File: src/analyzers/radar_categorization_config.json"
+
+### Tests (Part D)
+
+- `tests/contract/database/test_radar_schema.py` — five tests S1–S5 from Plan 022 Part D
+- `tests/contract/database/test_radar_categorization.py` — six tests C1–C6 from Plan 022 Part D
+- `tests/unit/test_radar_categorizer.py` — property-based + deterministic tests as shown in Plan 022 Part D. Uses `hypothesis`. **Check whether `hypothesis` is already in `requirements-test.txt`** — if not, add it; if it is, do nothing.
+
+## Architecture rules (non-negotiable)
+
+This codebase has strict component boundaries — see `.ai/principles.md` Principle 2.
+
+- `src/analyzers/radar_categorization.py` is in **analyzers**. It must:
+  - Be platform-agnostic (no GitHub or Azure DevOps SDK imports)
+  - **Not** import from `src/extractors/`, `src/database/storage.py`, or `src/workflows/`
+  - **Not** write to the database — return data structures only
+  - Take metrics as a `dict` parameter, don't query for them
+- The schema migration is the only DB-touching artifact. The workflow that populates `radar_blips` from real data is **Track B (a separate PR)**.
+
+If you find yourself wanting to import from `src/database/` or `src/workflows/`, stop — that's the workflow's job (Track B), not the analyzer's.
+
+## Test approach
+
+- Database contract tests use the standard pytest fixtures in `tests/contract/database/conftest.py` (look at neighbouring tests like `test_dependency_dashboard_views.py` for the pattern).
+- Categorization contract tests construct `RadarCategorizer` directly and assert ring/quadrant outputs for handcrafted metrics dicts.
+- Unit tests use `@hypothesis.given(...)` for property tests like "more repos/time → same or higher ring" (monotonic), plus deterministic asserts for "EOL never Adopt" and "high CVE exposure never Adopt".
+
+Tests run via `bash scripts/run-tests-docker.sh` — the canonical way. Python is **never** run on the host on this project; always Docker.
+
+## Acceptance criteria
+
+- [ ] Migration `database/migrations/018_tech_radar_schema.sql` exists, is idempotent, and creates the three tables and their indices as specified in Plan 022 Part A
+- [ ] Migration runs cleanly on a fresh DB (verify by running `bash scripts/run-tests-docker.sh` — migrations apply at test setup)
+- [ ] `RadarCategorizer.categorize()` correctly produces a `RadarBlip` for any valid metrics input
+- [ ] Config file is loaded at construction time; passing a custom `min_adopt_repos` in config changes categorization (test C6 verifies)
+- [ ] All 5 schema tests, 6 categorization contract tests, and the unit tests pass
+- [ ] `bash scripts/run-tests-docker.sh` exits 0 — full suite green
+- [ ] No imports from `src/extractors/`, `src/database/storage.py`, or `src/workflows/` in `radar_categorization.py`
+- [ ] No new endpoints in `src/api/` (that's Track C)
+- [ ] No new file in `src/workflows/` (that's Track B)
+
+## Branch and PR conventions
+
+- Branch from `main`: `git checkout -b plan-022/track-a-radar-schema-and-categorizer`
+- PR title: `feat(plan-022): radar schema migration and categorization engine`
+- PR body: link to `.ai/plans/022-tech-radar-publication-plan.md`, list the three tables, list the test counts (5 + 6 + N unit tests), state explicitly that Track B (workflow) and Track C (API) are out of scope.
+
+## ACCEPTANCE — DO NOT STOP UNTIL CI IS GREEN
+
+This is non-negotiable. Previous Copilot agents on this project have declared work done while CI was red, costing the user 2+ feedback rounds per task.
+
+1. **Before pushing**, run the full test suite locally: `bash scripts/run-tests-docker.sh`. Catch failures here, not in CI.
+2. After pushing your branch and opening the PR, run: `gh pr checks <PR#> --watch`
+3. If any required check fails:
+   1. `gh run view <run-id> --log-failed` to read the failure logs
+   2. Identify root cause; do **NOT** skip with `--no-verify`, disable tests, or weaken assertions to make CI pass
+   3. Fix the actual problem, commit, push
+   4. Repeat from step 2
+4. Required check: the `tests` workflow (`.github/workflows/tests.yml`).
+5. Only declare done when:
+   - All required checks are green
+   - PR has no merge conflicts
+   - Final PR comment links to the green check run
+
+If you cannot get CI green after 3 attempts, **stop** and post a comment explaining what you tried and what's blocking.
+
+## Out of scope (other tracks / waves)
+
+- `src/workflows/radar_publication.py` — that's Track B (separate PR, depends on this one being merged)
+- `/api/radar`, `/api/radar/history`, `/api/radar/export` endpoints — that's Track C
+- `src/api/radar_viewer.html` — **deleted from the plan**; the radar viewer is now a React route in Plan 025 Phase 1c
+- Any changes to existing extraction workflows or storage code
+
+## Estimated size
+
+~3 hours. Independent of all other Wave 1 prompts — disjoint files.

--- a/.ai/prompts/wave-1c-property-based-identity-tests.md
+++ b/.ai/prompts/wave-1c-property-based-identity-tests.md
@@ -1,0 +1,81 @@
+# Wave 1C — Plan 020 Component 1: Property-based contributor identity tests
+
+## Goal
+
+Add Hypothesis-based property tests for `get_or_create_contributor` in `src/database/storage.py`. The tests target invariants of contributor identity normalisation — idempotency, case-insensitivity, whitespace handling, unicode preservation, and uniqueness — using generated inputs rather than hand-picked cases. This catches "unknown unknown" pathologies that the existing adversarial fixture corpus (Plan 019 Layer A) doesn't cover.
+
+This prompt covers **Component 1 only** of Plan 020. Components 2 (live-API nightly) and 3 (production observability) are separate PRs.
+
+## Source plan
+
+`.ai/plans/020-property-based-live-api-observability.md`. Read **Component 1** sections 1.1 through 1.4. Skip Components 2 and 3 — out of scope.
+
+## Files to create
+
+- `tests/unit/strategies.py` — Hypothesis strategies for emails, case-perturbed variants, and unicode display names. Plan 020 Section 1.2 has the full skeleton (`email_strategy`, `case_variants`, `unicode_name_strategy`).
+- `tests/unit/test_contributor_identity_properties.py` — at least the 6 property tests in Plan 020 Section 1.3 (`test_idempotent`, `test_normalisation_stable`, `test_case_variants_collapse`, `test_whitespace_variants_collapse`, `test_distinct_emails_do_not_collide`, `test_unicode_names_round_trip`).
+
+## Files to modify (only if necessary)
+
+- `requirements-test.txt` — add `hypothesis` ONLY if it is not already present. Check first with `grep -i hypothesis requirements*.txt`. Do not duplicate.
+
+## Architecture rules
+
+- Tests live in `tests/unit/` because `get_or_create_contributor` is a unit-testable function (it just normalises and queries — no external API calls).
+- Mark tests with `@pytest.mark.unit` per the project's test conventions. They must complete within the existing unit-test timeout budget (use `@settings(max_examples=...)` to tune if needed; don't crank examples up to 1000 for "more coverage" — slow unit tests block everyone).
+- Tests must run via the existing `pytest tests/unit/` step in `scripts/run-tests-docker.sh` and `.github/workflows/tests.yml` — **no workflow changes needed**.
+- The strategies must generate emails that the existing normalisation can handle. If Hypothesis finds a real bug in `get_or_create_contributor`, **stop and report** — fixing normalisation is out of scope for this PR.
+
+## Verification step (the proof that these tests work)
+
+Plan 020 Verification step 2: temporarily revert `.strip().lower()` in `get_or_create_contributor`, run only the new tests, confirm Hypothesis shrinks to a minimal failing case (likely a 2-character case-variant email), then restore. This is a **manual verification** to do once before opening the PR — record the shrunk failing input in the PR body to prove the tests have teeth. Do **not** commit the reverted state.
+
+## Acceptance criteria
+
+- [ ] `hypothesis` is available in the test environment (added to `requirements-test.txt` only if not already there)
+- [ ] `tests/unit/strategies.py` exists with `email_strategy`, `case_variants`, and `unicode_name_strategy` per Plan 020 Section 1.2
+- [ ] `tests/unit/test_contributor_identity_properties.py` contains the 6 property tests from Plan 020 Section 1.3
+- [ ] All property tests pass: `bash scripts/run-tests-docker.sh` exits 0
+- [ ] Manual verification: reverting `.strip().lower()` causes `test_idempotent`, `test_case_variants_collapse`, and `test_whitespace_variants_collapse` to fail. PR body records the failure.
+- [ ] Tests complete within the existing unit-test timeout — no `@settings(max_examples=1000)` or similar; default 100 is fine
+- [ ] No changes to `src/database/storage.py` or any production code
+- [ ] No changes to existing tests in `tests/unit/` (additive only)
+
+## Branch and PR conventions
+
+- Branch from `main`: `git checkout -b plan-020/component-1-property-tests`
+- PR title: `test(plan-020): property-based identity tests for get_or_create_contributor`
+- PR body: link to `.ai/plans/020-property-based-live-api-observability.md`, brief summary of strategies + tests, the manual-verification record (failing input from the reverted-`.strip().lower()` run), and an explicit "Components 2 and 3 are separate PRs" note.
+
+## ACCEPTANCE — DO NOT STOP UNTIL CI IS GREEN
+
+This is non-negotiable. Previous Copilot agents on this project have declared work done while CI was red, costing the user 2+ feedback rounds per task.
+
+1. **Before pushing**, run the full test suite locally: `bash scripts/run-tests-docker.sh`. Catch failures here, not in CI.
+2. After pushing and opening the PR, run: `gh pr checks <PR#> --watch`
+3. If any required check fails:
+   1. `gh run view <run-id> --log-failed` to read the failure logs
+   2. Identify root cause; do **NOT** skip with `--no-verify`, disable tests, weaken assertions, or use `@pytest.mark.skip` to make CI pass
+   3. Fix the actual problem, commit, push
+   4. Repeat from step 2
+4. Required check: the `tests` workflow (`.github/workflows/tests.yml`).
+5. Only declare done when:
+   - All required checks are green
+   - PR has no merge conflicts
+   - Final PR comment links to the green check run **and** shows the manual-verification record
+
+If Hypothesis finds a real bug (test fails with `.strip().lower()` intact), **stop and report** — that's a production bug that needs the user's attention, not a "fix it and ship" situation. Comment on the PR with the failing input and wait for guidance.
+
+If you cannot get CI green after 3 attempts (and Hypothesis hasn't surfaced a real bug), stop and post a comment explaining what you tried and what's blocking.
+
+## Out of scope
+
+- Plan 020 Component 2 (live-API nightly) — separate PR
+- Plan 020 Component 3 (production observability) — separate PR
+- Cross-platform identity resolution — explicitly out of scope per Plan 020
+- Changes to `get_or_create_contributor` or any other production code
+- Changes to existing fixtures or test infrastructure
+
+## Estimated size
+
+~2–3 hours. Pure test code; no production changes; lowest risk of all Wave 1 prompts. Independent of all others.

--- a/.ai/prompts/wave-1d-extraction-health-observability.md
+++ b/.ai/prompts/wave-1d-extraction-health-observability.md
@@ -1,0 +1,109 @@
+# Wave 1D — Plan 020 Component 3: Production extraction-health observability
+
+## Goal
+
+Add a runtime health check that runs the same invariants as the CI fixture (Plan 019 Layer B / `tests/db_invariants.sql`) at the tail of each production extraction. Emit a Prometheus gauge per invariant and ship a Grafana dashboard with an alert rule. The single-source-of-truth principle is the point — invariants are defined once in `tests/db_invariants.sql` and consumed by CI, live-API nightly (Component 2, separate PR), and production (this PR).
+
+This prompt covers **Component 3 only** of Plan 020. Components 1 (property tests) and 2 (live-API nightly) are separate PRs.
+
+## Source plan
+
+`.ai/plans/020-property-based-live-api-observability.md`. Read **Component 3** sections 3.1 through 3.5. Skip Components 1 and 2 — out of scope.
+
+## Files to create
+
+- `src/utils/extraction_health.py` — defines `InvariantResult`, `HealthReport` dataclasses and the `compute_extraction_health(session, platform, repo_id=None) -> HealthReport` function. Parses `tests/db_invariants.sql` and runs each named invariant. See Plan 020 Section 3.1 for the dataclass shapes.
+- `src/utils/metrics.py` — **only if it does not already exist**. Check first: `grep -r "prometheus_client" src/`. If a metrics module already exists, **extend it** rather than creating a new one. The function to add is `emit_health_report(report: HealthReport)` which emits one `extraction_invariant_violations{platform, repo_id, invariant_name}` gauge per invariant.
+- `dashboards/extraction-health.json` — Grafana dashboard with the panels from Plan 020 Section 3.4: gauge per invariant + 7-day time-series. **Do not** add a top-link bar (`links[]` array) — Plan 025 Phase 2 has not yet shipped, and Plan 020 Section 3.4 explicitly says to omit it. Phase 2 will add the canonical bar later.
+- `docs/03-operations/extraction-health-monitoring.md` — operations doc per Plan 020 Section 3.5 (what each invariant means, what to do when it fires, how to add a new invariant).
+
+## Files to modify
+
+- `src/workflows/github_analysis.py` — at the tail (after the final commit), call `compute_extraction_health(session, platform="github", repo_id=repo_id)` and `emit_health_report(report)`. Wrap in `try/except Exception` that logs and swallows — **a bug in health-checking must never crash an extraction** (Plan 020 Compatibility Note).
+- `src/workflows/azure_devops_analysis.py` — same pattern for `platform="azure-devops"`.
+
+## Files to handle carefully
+
+- `tests/db_invariants.sql` — **read-only** in this PR. The file already exists from Plan 019. Do not modify it. This PR proves it can be consumed at runtime, not just by pytest.
+- If `tests/db_invariants.sql` is not packaged into the runtime Docker image, copy it during the image build (e.g. update `Dockerfile` to `COPY tests/db_invariants.sql /app/tests/db_invariants.sql`). The `compute_extraction_health` function should resolve the path from a known location — prefer `Path(__file__).parents[N] / "tests/db_invariants.sql"` over hardcoded `/app/...`.
+
+## Architecture rules (non-negotiable)
+
+This codebase has strict component boundaries — see `.ai/principles.md` Principle 2.
+
+- `src/utils/extraction_health.py` lives in **utils** because cross-cutting concerns (logging, metrics, health) belong there. It is allowed to:
+  - Use a SQLAlchemy session passed in
+  - Read `tests/db_invariants.sql`
+  - Return data structures
+  - Emit metrics (delegate to `src/utils/metrics.py`)
+- It must **not**:
+  - Import from `src/extractors/`, `src/analyzers/`, or `src/workflows/`
+  - Write to the database
+  - Call extraction code
+- The workflow files (`github_analysis.py`, `azure_devops_analysis.py`) already orchestrate; adding a tail-call to `compute_extraction_health` does not violate boundaries — workflows are allowed to call utils.
+- The `try/except` wrapper around the health call is critical. If health-checking blows up, log a warning and continue. **Never let observability crash production.**
+
+## Test approach
+
+- Unit-test `compute_extraction_health` with a mocked session and a stub invariants file — verify it parses the SQL, runs each query, and packs results correctly.
+- Add an integration test in `tests/contract/database/` that:
+  1. Inserts a known-orphan row (e.g. `pull_requests.author_id = 999999`)
+  2. Runs `compute_extraction_health`
+  3. Asserts the corresponding invariant has `violations > 0` and `sample_rows` populated
+- The "single source of truth" property (Plan 020 Verification step 6) is testable: add an invariant to `tests/db_invariants.sql` (in a test, monkey-patching the path) and assert `compute_extraction_health` picks it up without code changes.
+
+Tests run via `bash scripts/run-tests-docker.sh`. Python is **never** run on the host on this project.
+
+## Acceptance criteria
+
+- [ ] `src/utils/extraction_health.py` exists, parses `tests/db_invariants.sql`, returns `HealthReport`
+- [ ] `src/utils/metrics.py` exposes `emit_health_report` (new file, or extension of an existing metrics module — check first)
+- [ ] Both production workflow files call `compute_extraction_health` + `emit_health_report` at the tail, wrapped in `try/except` that logs and swallows
+- [ ] `dashboards/extraction-health.json` renders the gauge-per-invariant + 7-day time-series panels. No `links[]` array (Plan 025 Phase 2 will add it later).
+- [ ] Grafana dashboard auto-provisions via the existing `grafana/provisioning/dashboards/dashboards.yml` config
+- [ ] Alert rule fires when any invariant gauge is non-zero for >1 hour (configure within the dashboard JSON or as a separate alert rule file — match existing alert conventions in the repo)
+- [ ] `docs/03-operations/extraction-health-monitoring.md` explains the signal, the remediation path, and how to add a new invariant
+- [ ] Tests added: unit test for `compute_extraction_health`, integration test injecting a synthetic violation
+- [ ] `bash scripts/run-tests-docker.sh` exits 0 — full suite green
+- [ ] `tests/db_invariants.sql` is unchanged
+- [ ] No imports from `src/extractors/`, `src/analyzers/`, or `src/workflows/` in `extraction_health.py`
+- [ ] Health-call wrapping verified: a deliberate `raise Exception` injected at the top of `compute_extraction_health` does **not** fail the extraction workflow tests (revert the injection before pushing, but record this verification in the PR body)
+
+## Branch and PR conventions
+
+- Branch from `main`: `git checkout -b plan-020/component-3-extraction-health`
+- PR title: `feat(plan-020): production extraction-health observability`
+- PR body: link to `.ai/plans/020-property-based-live-api-observability.md`, list the new files, the modified workflows, the dashboard, and the operations doc. Explicitly note: "Components 1 and 2 are separate PRs", "tests/db_invariants.sql is unchanged (Plan 019 artifact)", "Plan 025 Phase 2 will add the top-link bar to the new dashboard later".
+
+## ACCEPTANCE — DO NOT STOP UNTIL CI IS GREEN
+
+This is non-negotiable. Previous Copilot agents on this project have declared work done while CI was red, costing the user 2+ feedback rounds per task.
+
+1. **Before pushing**, run the full test suite locally: `bash scripts/run-tests-docker.sh`. Catch failures here, not in CI.
+2. After pushing and opening the PR, run: `gh pr checks <PR#> --watch`
+3. If any required check fails:
+   1. `gh run view <run-id> --log-failed` to read the failure logs
+   2. Identify root cause; do **NOT** skip with `--no-verify`, disable tests, weaken assertions, swallow exceptions in production code that should propagate, or use `@pytest.mark.skip` to make CI pass
+   3. Fix the actual problem, commit, push
+   4. Repeat from step 2
+4. Required check: the `tests` workflow (`.github/workflows/tests.yml`).
+5. Only declare done when:
+   - All required checks are green
+   - PR has no merge conflicts
+   - Final PR comment links to the green check run **and** confirms the swallow-exception verification (deliberate `raise` in `compute_extraction_health` did not break extraction workflow tests)
+
+If `prometheus_client` is not yet a project dependency, **stop and ask** before adding it — Plan 020 Section 3.3 says to fall back to structured logs only if Prometheus infrastructure isn't already wired. Do not introduce a new infrastructure dependency unilaterally.
+
+If you cannot get CI green after 3 attempts, stop and post a comment explaining what you tried and what's blocking.
+
+## Out of scope
+
+- Plan 020 Component 1 (property tests) — separate PR
+- Plan 020 Component 2 (live-API nightly + canary secrets) — separate PR
+- Adding new invariants to `tests/db_invariants.sql` — that file is Plan 019's artifact
+- Cross-platform identity resolution — explicitly out of scope per Plan 020
+- Adding a top-link bar to `extraction-health.json` — Plan 025 Phase 2 owns that
+
+## Estimated size
+
+~4–6 hours. Touches workflows in production code paths, so the swallow-exception wrapper is the highest-risk part — get the test for that right first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ For detailed operational specifics and reference material, see:
 1. Warm greeting (personalize it—vary language/style)
 2. Quick check: `git status` (should be on feature branch, not main)
 3. Check for uncommitted changes
-4. Read `PROGRESS.md` to catch up on last session
+4. Read `PROGRESS.md` if it exists to catch up on last session
 5. Either summarize incomplete work or present backlog priorities
 
 **Environment Setup**: If `.env` is missing or incomplete, generate it by running `./Start-RepoAnalysis.sh --regenerate-env` (or `./start-repoanalysis.sh --regenerate-env`) and have the user answer the interactive prompts.
@@ -24,13 +24,16 @@ For detailed operational specifics and reference material, see:
 **Remember**: Principles over rules. When uncertain, identify which principle applies and use judgment.
 
 **Skills**: Project skills have two locations:
+
 - `.ai/skills/` — source of truth (edit skills here)
 - `.claude/skills/` — deployed copy (loaded by Claude Code automatically on checkout)
 
 At session start, check for drift between the two:
+
 ```
 diff -rq .ai/skills/ .claude/skills/
 ```
+
 If there are differences, alert the user — the deployed copy is out of sync with the source.
 
 **Tools**: Tell the user if any tools or MCPs are listed in .ai\agents or elsewhere but something is preventing those tools from being used

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,11 +2,13 @@
 
 ---
 
-## Session: 2026-05-03 — Plan 024 Investigation Closeout
+## Session: 2026-05-03 — Plan 025 (née 024) Investigation Closeout
 
 ### Summary
 
-User filled in Themes A–E answers in the investigation and answered Plan 024's open questions. Closed out the investigation as **Outcome 2 selected**, flipped Plan 024 from DRAFT to APPROVED, ran the three audits, and re-sequenced the phases.
+User filled in Themes A–E answers in the investigation and answered the open questions. Closed out the investigation as **Outcome 2 selected**, flipped the plan from DRAFT to APPROVED, ran the three audits, and re-sequenced the phases.
+
+**Renumber**: discovered late in session that PR #83 already reserved Plan 024 for "auth error taxonomy". Renamed our work to **Plan 025** and updated cross-references in plans 020, 022, the investigation, and memory. Phase numbering inside Plan 025 is unchanged.
 
 Key decisions captured:
 
@@ -25,7 +27,7 @@ Three audits added to investigation as historical record:
 ### Files Modified
 
 - `.ai/investigations/grafana-ui-shortcomings.md` (RESOLVED, synthesis filled, audits appended)
-- `.ai/plans/024-bespoke-admin-and-navigation-ui.md` (APPROVED, decisions section, phase reorder, 1a/1b split, concrete drill-down list)
+- `.ai/plans/025-bespoke-admin-and-navigation-ui.md` (APPROVED, decisions section, phase reorder, 1a/1b split, concrete drill-down list)
 - `PROGRESS.md` (this entry)
 
 ### Next Session — Pickup Points
@@ -60,7 +62,7 @@ Wrote two artefacts to capture the decision before any code changes:
   three-outcome synthesis matrix. Pre-investigation lean is **Outcome 2**
   (split). Includes three concrete `jq` audits the user can run to ground
   the answers in data.
-- [.ai/plans/024-bespoke-admin-and-navigation-ui.md](.ai/plans/024-bespoke-admin-and-navigation-ui.md) —
+- [.ai/plans/025-bespoke-admin-and-navigation-ui.md](.ai/plans/025-bespoke-admin-and-navigation-ui.md) —
   **DRAFT, gated on Outcome 2**. Three phases: (1) React+Vite+TS admin MVP at
   `web/admin-ui/` consuming the existing 7 Flask endpoints (no new backend),
   (2) uniform 5-entry top-link bar across all 12 dashboards, (3) fill in the
@@ -71,7 +73,7 @@ Wrote two artefacts to capture the decision before any code changes:
 ### Files Modified
 
 - `.ai/investigations/grafana-ui-shortcomings.md` (new)
-- `.ai/plans/024-bespoke-admin-and-navigation-ui.md` (new — DRAFT)
+- `.ai/plans/025-bespoke-admin-and-navigation-ui.md` (new — DRAFT)
 
 ### Next Session — Pickup Points
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,101 @@
 
 ---
 
+## Session: 2026-05-03 — Plan 024 Investigation Closeout
+
+### Summary
+
+User filled in Themes A–E answers in the investigation and answered Plan 024's open questions. Closed out the investigation as **Outcome 2 selected**, flipped Plan 024 from DRAFT to APPROVED, ran the three audits, and re-sequenced the phases.
+
+Key decisions captured:
+
+- **Outcome 2 confirmed** — split admin from Grafana analytics
+- **Framework**: React + Vite + TypeScript at `web/admin-ui/`, no auth for MVP
+- **Coexistence**: React UI lives alongside Grafana home, doesn't replace it. Grafana top-link bar gets a separate `Admin UI` slot (option (a))
+- **Phase order reversed**: Phase 2 (uniform top-link bar) and Phase 3 (missing drill-downs) ship first — Theme E.2 says they capture 80% of the pain. Phase 1 (React MVP) third
+- **Phase 1 narrowed**: split into 1a (rescan triggers + health, Theme C.1's actually-used workflow) and 1b (Repository List + Compute Metrics, deferred)
+
+Three audits added to investigation as historical record:
+
+1. **Top-link audit** — 7 distinct shapes across 12 dashboards (technology-landscape regression: no bar at all)
+2. **Drill-down audit** — ~12 high-value gaps; only 4 panels currently have data links. Highest-value gap is `library-detail-deep-dive` "Repositories Using $package_name" (it's a leaf with no exit)
+3. **Admin action inventory** — 4 action panels become React (rescan ×2, compute metrics, health); 9 observability panels stay in Grafana
+
+### Files Modified
+
+- `.ai/investigations/grafana-ui-shortcomings.md` (RESOLVED, synthesis filled, audits appended)
+- `.ai/plans/024-bespoke-admin-and-navigation-ui.md` (APPROVED, decisions section, phase reorder, 1a/1b split, concrete drill-down list)
+- `PROGRESS.md` (this entry)
+
+### Next Session — Pickup Points
+
+1. **Phase 2 implementation** on a new feature branch — mechanical 6-entry top-link bar across 11 dashboards (`dashboard-home.json` skipped). Coding-agent ready; the plan's Scope section enumerates the exact entries.
+2. **Phase 3 implementation** — ~12 specific `fieldConfig.overrides[]` edits enumerated in the plan. Use the existing `security-dashboard.json` "Repository Security Overview" data link as the canonical pattern.
+3. **Phase 1 scaffolding** comes after Phases 2+3 ship — React + Vite + TS at `web/admin-ui/`.
+
+### Notes
+
+- Branch: `feat/plan-024-investigation-closeout`. Doc-only changes; no code touched.
+- No tests run — investigation/plan documents only.
+
+---
+
+## Session: 2026-05-01 — Bespoke Web UI Decision: Investigation + Plan 024 Drafted
+
+### Summary
+
+Discussed the user's frustration with Grafana for cross-dashboard navigation and
+relational drill-down (especially the security dashboard's missing
+"vulnerability → repo" links), and the awkwardness of admin/CRUD workflows
+embedded in `dashboards/admin-dashboard.json`. Recommendation: **split admin
+from analytics** — bespoke React UI for admin + nav hub, Grafana stays for
+analytics charts but gets a uniform top-link bar and the missing data links.
+
+Wrote two artefacts to capture the decision before any code changes:
+
+- [.ai/investigations/grafana-ui-shortcomings.md](.ai/investigations/grafana-ui-shortcomings.md) —
+  question-driven analysis. Five themes (cross-dashboard nav, relational
+  drill-down, admin tool fit, analytics tool fit, effort/audience) with a
+  three-outcome synthesis matrix. Pre-investigation lean is **Outcome 2**
+  (split). Includes three concrete `jq` audits the user can run to ground
+  the answers in data.
+- [.ai/plans/024-bespoke-admin-and-navigation-ui.md](.ai/plans/024-bespoke-admin-and-navigation-ui.md) —
+  **DRAFT, gated on Outcome 2**. Three phases: (1) React+Vite+TS admin MVP at
+  `web/admin-ui/` consuming the existing 7 Flask endpoints (no new backend),
+  (2) uniform 5-entry top-link bar across all 12 dashboards, (3) fill in the
+  missing Grafana data links. Stays out of `src/extractors/`, `src/analyzers/`,
+  `src/database/`, `src/workflows/` — Architecture Guardian boundaries
+  unchanged.
+
+### Files Modified
+
+- `.ai/investigations/grafana-ui-shortcomings.md` (new)
+- `.ai/plans/024-bespoke-admin-and-navigation-ui.md` (new — DRAFT)
+
+### Next Session — Pickup Points
+
+1. **Fill in investigation Themes A–C** (cross-dashboard nav, relational
+   drill-down, admin workflows). These three drive whether Plan 024 is the
+   right shape. Theme E (effort/audience) is also worth answering early.
+2. **Run the three audits** the investigation prescribes (top-link audit,
+   drill-down audit, admin action inventory) — these turn opinion into data.
+3. **Confirm or adjust Plan 024 open questions** at the bottom of the plan:
+   framework choice (React vs Vue/Svelte/HTMX), location (`web/admin-ui/` vs
+   alternatives), no-auth-for-MVP acceptable, whether the React Home replaces
+   `dashboards/dashboard-home.json`.
+4. Once Outcome 2 confirmed and open questions resolved → flip Plan 024 from
+   DRAFT to DESIGN and start Phase 1 scaffolding on a new feature branch.
+
+### Notes
+
+- No code changes this session — pure planning. Currently on `main`, working
+  tree clean. Feature branch should be created tomorrow before any
+  implementation work (Principle 4).
+- Plan 023 (Grafana Home nav links) is the most recent shipped plan; this
+  plan is `024`.
+
+---
+
 ## Session: 2026-04-26 - Plan 012 Complete: R-A/R-B Implementation Verified
 
 ### Summary


### PR DESCRIPTION
## Summary

Doc-only branch closing out the Grafana UI shortcomings investigation, approving the bespoke web UI plan (renumbered 024 → 025 to dodge PR #83), aligning plans 020/021/022 with the React UI direction, and queuing four ready-to-paste Wave 1 coding-agent prompts.

## What changed

- **Investigation** (`.ai/investigations/grafana-ui-shortcomings.md`): OPEN → RESOLVED. Synthesis table filled with **Outcome 2** selected. Three audits appended (top-link, drill-down, admin actions) as the historical record that drives the next phase of work.
- **Plan 025** (`.ai/plans/025-bespoke-admin-and-navigation-ui.md`, formerly 024): DRAFT → APPROVED. Decisions section captures the five answered open questions. Phases re-sequenced to **2 → 3 → 1** per Theme E.2's 80/20 finding. Phase 1 split into 1a (rescan + health, must-ship), 1b (Repository List + Compute Metrics, deferred), 1c (Tech Radar viewer, depends on Plan 022), 1d (Library detail page, Plan 021 endpoints already live). Phase 2 spec pinned (Admin UI absolute URL, full replacement of `links[]`).
- **Plan 022** (`.ai/plans/022-tech-radar-publication-plan.md`): drop `src/api/radar_viewer.html` in favour of a React route at Plan 025 Phase 1c. Backend (schema + categorizer + workflow + 3 endpoints) unchanged.
- **Plan 020** (`.ai/plans/020-property-based-live-api-observability.md`): one-liner instructing the agent who creates `extraction-health.json` to copy the canonical Plan 025 top-link bar (or omit if 025 hasn't shipped yet).
- **Renumber**: Plan 024 → 025 because PR #83 already reserved 024 for "auth error taxonomy". Cross-references updated everywhere.
- **Wave 1 prompts** (`.ai/prompts/`): four self-contained, ready-to-paste briefs for parallel coding agents. Every prompt includes a non-negotiable "do not stop until CI is green" acceptance block to address the recurring 2-round-feedback loop on prior Copilot PRs.

## Test plan

- [x] No code changes — pure docs
- [x] No Python files touched (pre-commit hook confirms: `✓ No Python files to check`)
- [x] All renumbered cross-references verified with `grep` (no stale "Plan 024" references to our work remain)
- [x] Renumbered file passes basic markdown sanity (renders cleanly in IDE)
- [ ] Reviewer: spot-check the four prompts in `.ai/prompts/` for clarity before dispatching to Copilot
- [ ] Reviewer: confirm the renumber note in Plan 025 is sufficient context for future readers

## Follow-ups

This PR ends in a queued state. Once merged, dispatch coding agents in waves:

1. **Wave 1A** first as the prompt-template validation: `.ai/prompts/wave-1a-grafana-uniform-top-link-bar.md`
2. After 1A's output looks right, dispatch 1B / 1C / 1D in parallel — disjoint files, no merge conflicts
3. Wave 2 prompts (Plan 025 Phase 3, Plan 022 Track B, Plan 020 Component 2) drafted on demand once Wave 1 PRs land