### PR TITLE
docs(plans-021-022): close out — flip Plan 022 to IMPLEMENTED, refresh README

### DIFF
--- a/.ai/plans/022-tech-radar-publication-plan.md
+++ b/.ai/plans/022-tech-radar-publication-plan.md
@@ -1,6 +1,8 @@
 # Plan 022: Thoughtworks Tech Radar Publication (FR-6)
 
-## Status: DESIGN (Ready for Implementation)
+## Status: IMPLEMENTED ✅
+
+Merged in [PR #74](https://github.com/stickleprojects/azure_devops_analyzer/pull/74) (`db5ffd6`, 2026-04-26). Verified 2026-05-03: all contract/unit tests pass (53 passed; 4 hypothesis property-based tests skipped because `hypothesis` is not installed in the test image — see `tests/unit/test_radar_categorizer.py::TestCategorizationPropertyBased`).
 
 **Implements**: FR-6.1, FR-6.2, FR-6.3, FR-6.4, FR-6.5, FR-6.6, FR-6.7
 

--- a/.ai/plans/README-plans-021-022-parallel.md
+++ b/.ai/plans/README-plans-021-022-parallel.md
@@ -1,11 +1,19 @@
 # Plans 021 & 022: Parallel Implementation Strategy for Copilot Delegation
 
-## Status (2026-04-26)
+## Status: COMPLETE — both plans merged 2026-04-26
 
-| Plan | PR | Status | Notes |
-|------|----|--------|-------|
-| 021 — Dependency Vulnerability & EOL Dashboard (FR-5) | [#73](https://github.com/stickleprojects/azure_devops_analyzer/pull/73) | ✅ **Merged** 2026-04-26 (commit `c4346ad`) | All tracks shipped in single PR |
-| 022 — Thoughtworks Tech Radar Publication (FR-6) | [#74](https://github.com/stickleprojects/azure_devops_analyzer/pull/74) | ✅ **Merged** 2026-04-26 (commit `db5ffd6`) | All tracks shipped in single PR; merge conflict with Plan 021 in `src/api/rescan.py` resolved before merge |
+| Plan | Implementation PR | Status |
+|------|------------------|--------|
+| 021 — Dependency Vulnerability & EOL Dashboard (FR-5) | [#73](https://github.com/stickleprojects/azure_devops_analyzer/pull/73) (`c4346ad`) | ✅ Merged 2026-04-26 |
+| 022 — Thoughtworks Tech Radar Publication (FR-6) | [#74](https://github.com/stickleprojects/azure_devops_analyzer/pull/74) (`db5ffd6`) | ✅ Merged 2026-04-26 |
+
+### Post-merge documentation follow-ups
+
+| PR | Date | What it changed |
+|----|------|-----------------|
+| [#75](https://github.com/stickleprojects/azure_devops_analyzer/pull/75) (`efe30d1`) | 2026-04-26 | Recorded both plans complete; added `.claude/settings.json` |
+| [#86](https://github.com/stickleprojects/azure_devops_analyzer/pull/86) (`a206801`) | 2026-05-03 | Wave 1B: PROGRESS.md note describing tech radar schema/categorizer (titled as a feat, but the implementation already shipped in #74 — diff is docs-only, 44 lines in `PROGRESS.md`) |
+| [#89](https://github.com/stickleprojects/azure_devops_analyzer/pull/89) (`7e581ad`) | 2026-05-03 | Plan 021 docs/visualization/requirements alignment (docs-only, 72 lines) |
 
 ### Outcome vs. plan
 
@@ -32,9 +40,9 @@
 
 ---
 
-## Original Plan (Historical)
+## Original Plan (Historical — superseded by actual execution)
 
-The strategy below was the pre-implementation delegation plan. Kept for reference; actual execution was simpler (one PR per plan rather than per track).
+> **This section is preserved for archaeology only.** Everything below was the pre-implementation delegation strategy — three tracks per plan, multiple parallel Copilot agents, six PRs total. Actual execution was simpler: one PR per plan, both implemented by Copilot concurrently. Track-level effort estimates and PR sequencing below did not match reality and should not be used as a template for future plans.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Plan 022's own status header was still `DESIGN (Ready for Implementation)` even though all code shipped in #74 on 2026-04-26. Flipped to `IMPLEMENTED ✅` with PR/commit reference and a verification note.
- Refreshed `.ai/plans/README-plans-021-022-parallel.md` to match Plan 020's close-out style: clear `Status: COMPLETE` block at top, list of post-merge doc-only follow-ups (#75/#86/#89), and the 300-line pre-implementation strategy bracketed as superseded archaeology.
- Notable correction: PR #86's title (`feat(plan-022): radar schema migration and categorization engine`) is misleading — its actual diff is **44 lines in `PROGRESS.md`**, since the schema/categorizer/workflow/API all shipped in #74 a week earlier. Same shape for #89 vs Plan 021. Documented in the README so future readers don't double-count.

Docs only — no code changes.

## Verification

Tests run on this branch via `bash scripts/run-tests-docker.sh` (Docker), all green:

| File | Result |
|------|--------|
| `tests/contract/database/test_dependency_dashboard_views.py` | 9/9 |
| `tests/contract/api/test_dependency_dashboard_api.py` | 5/5 |
| `tests/contract/api/test_radar_endpoints.py` | 8/8 |
| `tests/contract/database/test_radar_schema.py` | 5/5 |
| `tests/contract/database/test_radar_categorization.py` | 6/6 |
| `tests/unit/test_radar_categorizer.py` | 29/29 (4 hypothesis tests skipped — see #fix-pr) |

The hypothesis-skip is fixed in a separate PR (`fix/run-tests-docker-hypothesis`) — independent, can merge in either order.

## Test plan

- [ ] CI green
- [ ] Read-through of the README to confirm the close-out framing reads well

🤖 Generated with [Claude Code](https://claude.com/claude-code)