### PR TITLE
fix(scripts): add hypothesis to run-tests-docker.sh pip install

### DIFF
--- a/scripts/run-tests-docker.sh
+++ b/scripts/run-tests-docker.sh
@@ -155,7 +155,7 @@ run_pytest_in_runner() {
     # Dependencies are started explicitly in start_test_db_and_migrations.
     # Avoid re-running one-shot services like test-migrations for every pytest call.
     docker compose --env-file "$RESOLVED_ENV_FILE" -f "$COMPOSE_FILE" run --rm --no-deps test-runner \
-        sh -c "pip install pytest pytest-cov pytest-asyncio pytest-mock && ${pytest_cmd}" || exit_code=$?
+        sh -c "pip install pytest pytest-cov pytest-asyncio pytest-mock hypothesis && ${pytest_cmd}" || exit_code=$?
     return $exit_code
 }
 


### PR DESCRIPTION
## Summary

`scripts/run-tests-docker.sh:158` (the `run_pytest_in_runner` helper invoked when you pass a specific test path) pip-installs its own minimal test deps before pytest. It was missing `hypothesis`, even though both `requirements.txt` and `docker-compose.test.yml`'s default test-runner command already declare it.

Effect of the omission:

- Tests that import `hypothesis` directly **error at collection** when run via this script — e.g. `tests/unit/test_contributor_identity_properties.py` (Plan 020 Component 1 property tests) failed with `ModuleNotFoundError: No module named 'hypothesis'`.
- Tests that wrap the import in `try/except` **silently skip** — e.g. the 4 `TestCategorizationPropertyBased` tests in `tests/unit/test_radar_categorizer.py`.

The compose file's own pip-install line already has `hypothesis`, so this PR just brings the script's helper in line with the declared deps.

## Verification (on this branch)

| Test file | Before | After |
|-----------|--------|-------|
| `tests/unit/test_contributor_identity_properties.py` | ERROR (collection) | **6/6 PASS** |
| `tests/unit/test_radar_categorizer.py` | 29 PASS + 4 SKIP | **33/33 PASS** |

## Test plan

- [ ] CI green
- [ ] Confirm Plan 020's property tests now run in the suite (they were broken-but-silent before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)