### PR TITLE
docs(plan-025): status reconcile, visual radar (MIT Zalando), and parallel 1c/1d agent prompts

### DIFF
--- a/.ai/plans/025-bespoke-admin-and-navigation-ui.md
+++ b/.ai/plans/025-bespoke-admin-and-navigation-ui.md
@@ -2,7 +2,7 @@
 
 > **Renumber note (2026-05-03)**: Originally drafted as Plan 024. Renumbered to 025 because PR #83 (open at drafting time) reserved Plan 024 for "auth error taxonomy and view consistency". Phase numbering inside this document is unchanged.
 
-## Status: IN PROGRESS — Phase 2 ✅ (PR #85, gap fixed: Task A ✅ PR #103) · Phase 3 ✅ (PR #94) · Phase 1a ✅ (PR #96) · Phase 1b ✅ (PR #104) · Phase 1c/1d deferred
+## Status: IN PROGRESS (mostly complete) — Phase 2 ✅ (PR #85, gap fixed: Task A ✅ PR #103) · Phase 3 ✅ (PR #94) · Phase 1a ✅ (PR #96) · Phase 1b ✅ (PR #104) · **Phase 1c/1d deferred — the only remaining work**
 
 **Implements**: A small React frontend that owns admin/operational workflows and coexists with Grafana — Grafana remains the home for analytics charts and the primary "Home" landing.
 
@@ -10,24 +10,52 @@
 
 ---
 
-## What's next (agent entry point — 2026-05-25)
+## What's next (agent entry point — updated 2026-05-25)
 
-Two tasks remain. Pick the one the user asks for; do not implement both in one PR.
+Tasks A and B are **done** (PRs #103, #104). The only remaining work is the two
+deferred optional phases — **1c (Tech Radar viewer)** and **1d (Library detail
+page)**. Both dependencies are now met (Plans 022 and 021 respectively), so
+either can be picked up independently. Pick the one the user asks for; do not
+implement both in one PR.
 
 ### Task A — Fix extraction-health.json Phase 2 gap ✅ (PR #103)
 
 `dashboards/extraction-health.json` had no `links[]` array. Fixed in PR #103.
+
 ### Task B — Phase 1b: Compute Metrics trigger + Repository List page ✅ (PR #104)
 
 Merged. `ExtractionPage.tsx` extended with Compute Service Metrics button; `RepositoriesPage.tsx` added with filterable table and per-row Rescan/Remove buttons.
 
-### Task C — Phase 1c: Tech Radar viewer route (deferred, ~2–3 days)
+### Task C — Phase 1c: Tech Radar viewer route (deferred, ~3–4 days) — REMAINING
 
 Plan 022 is now complete (merged). Backend endpoints available:
-- `GET /api/radar` — returns Thoughtworks-format JSON
+- `GET /api/radar` — returns Thoughtworks-format JSON (`documentTitle`, `quadrants`, `rings`, `entries[]`)
 - `GET /api/radar/history` — returns timeline
 
-Add React routes `/radar` and `/radar/history` to `web/admin-ui/`. The `/radar` route renders the JSON as a categorised blip list (no iframe to thoughtworks.com). The `/radar/history` route renders a sortable table. Add tiles on `HomePage.tsx`. Unit-test both pages.
+The `/radar` route renders an **actual visual radar** (the circular blip diagram) using the **MIT-licensed** D3 [Zalando tech-radar](https://github.com/zalando/tech-radar) renderer — **not** a list and **not** an iframe to thoughtworks.com. The `/radar/history` route stays a sortable table (timeline data, not a snapshot). Add tiles on `HomePage.tsx`.
+
+> **Why Zalando, not Thoughtworks BYOR:** the obvious pick — Thoughtworks' own build-your-own-radar — is **AGPL-3.0**, which would copyleft the bundled `admin-ui` frontend. Zalando's tech-radar is the same Thoughtworks-derived circular visual but **MIT-licensed** (© 2017–2025 Zalando SE), so it drops in with no copyleft strings. Decision recorded 2026-05-25 (see PROGRESS.md).
+
+**Integration approach (single-file D3 renderer):**
+- Vendor Zalando's single `radar.js` (the `radar_visualization()` function, D3 v7) into `web/admin-ui/src/vendor/zalando-radar/`. Pin a release (e.g. `radar-0.12.js`), record the version, and keep the MIT copyright header in the file.
+- Add runtime dep: `d3` (v7).
+- It ships as a global-function script, not ESM — lightly adapt `radar.js` to `export function radar_visualization(config)` (trivial; MIT permits modification). Build a thin React wrapper `RadarChart.tsx` that calls it inside `useEffect` against a ref'd `<svg id="radar">`; clear the SVG on unmount/re-render.
+- **Data mapping** (`/api/radar` → Zalando config) — Zalando uses **numeric indices**, our API uses **names**, so the mapping must convert:
+  - `quadrants`: pass `[{name}]` (4). Zalando places them clockwise from bottom-right; order is cosmetic.
+  - `rings`: pass `[{name, color}]` indexed 0→3 inner→outer — our order Adopt/Trial/Assess/Hold already matches (Adopt = innermost = 0). Pass `rings[].color` through.
+  - `entries`: per blip → `{ label: entry.label, quadrant: <index of entry.quadrant in quadrants>, ring: <index of entry.ring in rings>, moved: entry.isNew ? 2 : (entry.isMoved ? 1 : 0), active: true }`. (Zalando `moved`: `2`=new, `1`=moved in, `0`=no change, `-1`=moved out; `/api/radar` has no moved-out signal, so `-1` is unused unless derived from `/api/radar/history`.)
+- Handle the empty-publication case (`entries: []`) — show a "no radar published yet" placeholder, not a broken chart.
+
+**Licensing:** Zalando tech-radar is **MIT** — keep the copyright header in the vendored file and add a line to the repo's third-party notices. No copyleft obligation (this is the whole reason it was chosen over BYOR).
+
+**Testing:** D3/SVG renders poorly under jsdom, so don't assert on the drawn chart in Vitest. Instead: (1) unit-test the pure mapping function (API `entries[]` → Zalando config) hard — quadrant→index, ring→index, `moved` derivation from `isNew`/`isMoved`, empty case; (2) a light smoke test that the component mounts and emits an `<svg>` with the expected blip count; (3) cover the visual render in the Playwright e2e suite (`web/admin-ui/e2e/`).
+
+### Task D — Phase 1d: Library detail page (deferred, ~2–3 days) — REMAINING
+
+Plan 021 is now complete (merged). Backend endpoint available:
+- `GET /api/packages/library/<name>/<ecosystem>` — metadata + CVE list + adoption timeline + per-repo usage
+
+Add a React route `/library/:ecosystem/:name` to `web/admin-ui/` consuming that endpoint. Render metadata + CVE list + adoption timeline + per-repo usage. Coexists with the Grafana `library-detail-deep-dive.json` dashboard (Phase 3 data links still point at the Grafana version). Unit-test the page.
 
 ---
 
@@ -123,10 +151,12 @@ Skipped (no obvious target or external link): `repository-deep-dive` Branch Deta
 
 **Phase 1c (deferred — Tech Radar viewer, Plan 022 dependency now met ✅):**
 
-- React route at `/radar` rendering the Thoughtworks-format JSON returned by `GET /api/radar` (Plan 022 Part C).
+- React route at `/radar` rendering an **actual visual radar** — the circular blip diagram — from the Thoughtworks-format JSON returned by `GET /api/radar` (Plan 022 Part C), using the vendored **MIT-licensed** D3 [Zalando tech-radar](https://github.com/zalando/tech-radar) renderer. **Not** a list, **not** an iframe to thoughtworks.com.
 - React route at `/radar/history` rendering the timeline from `GET /api/radar/history` as a sortable table.
 - Replaces the now-removed `src/api/radar_viewer.html` from Plan 022. Plan 022's backend is unchanged and ships independently of this phase.
-- Rationale: Tech Radar is a leadership-facing artifact (Theme E.1 audience). A React route is much cleaner than an iframe to thoughtworks.com or a static HTML wrapper, and is exactly the kind of high-visibility surface that justifies the React investment beyond admin chores.
+- **Why a real radar:** the backend already serves canonical radar JSON (4 quadrants, 4 colour-coded rings, blip `quadrant`/`ring`/`isNew`/`isMoved`), so the data layer is done — this is purely a frontend rendering choice. The circular radar is the recognised, leadership-facing artifact (Theme E.1 audience) and is exactly the high-visibility surface that justifies the React investment beyond admin chores.
+- **Why Zalando, not Thoughtworks BYOR:** the obvious choice (Thoughtworks' own build-your-own-radar) is **AGPL-3.0**, which would copyleft the bundled `admin-ui` frontend. Zalando's tech-radar is the same Thoughtworks-derived visual but **MIT-licensed**, so it carries no copyleft obligation. Decision recorded 2026-05-25 (PROGRESS.md).
+- **Integration:** vendor Zalando's single `radar.js` (`radar_visualization()`, D3 v7) into `web/admin-ui/src/vendor/zalando-radar/` (pin a release, keep the MIT header), add `d3`, adapt to an ESM export, and wrap in a `RadarChart.tsx` React component driven by a data-mapping function. Note: Zalando uses **numeric** quadrant/ring indices while `/api/radar` uses names — the mapping converts name→index and derives `moved` from `isNew`/`isMoved`. See Task C in "What's next" for the full mapping and testing detail.
 
 **Phase 1d (deferred — Library detail page, Plan 021 dependency now met ✅):**
 
@@ -291,6 +321,8 @@ For each gap enumerated in the Scope section, add a `fieldConfig.overrides[]` en
 | Maintenance burden of a second codebase outweighs benefit                                | Medium      | Phase 1a is deliberately tiny (3 pages, no auth, no fancy state). Phase 1b only ships if 1a's value is real.                                                                    |
 | Auth becomes urgent later                                                                | Medium      | Plan now: when the Flask API gets auth, add a login page and an `Authorization` header to the API client. Both are well-trodden patterns; not a blocker today.                  |
 | nginx + reverse proxy complexity in Compose                                              | Low         | Pattern is standard; many examples online. Worst case, serve via Vite preview in dev and skip nginx until prod really matters.                                                  |
+| Radar renderer licensing (Phase 1c)                                                      | Low         | **Resolved 2026-05-25:** chose MIT-licensed Zalando tech-radar over AGPL-3.0 Thoughtworks BYOR to avoid copyleft on the frontend bundle. Keep the MIT header + a third-party notice. |
+| Zalando radar ships as a global-function script, not ESM (Phase 1c)                       | Low         | Single `radar.js` — trivially adapted to an ESM export (MIT permits). Drive it from a unit-tested name→index mapping function so the React seam is the only integration risk. |
 
 ---
 
@@ -333,7 +365,7 @@ web/admin-ui/src/pages/
   RepositoriesPage.test.tsx          ✅
 ```
 
-**Estimated effort**: Phase 1c/1d ~2–3 days each.
+**Estimated effort**: Phase 1c ~3–4 days (visual radar — vendor Zalando's single-file MIT D3 radar + ESM adapt + React wrapper + name→index data mapping + tests). Phase 1d ~2–3 days.
 
 ---
 

--- a/.ai/prompts/025-phase1c-tech-radar-viewer.md
+++ b/.ai/prompts/025-phase1c-tech-radar-viewer.md
@@ -1,0 +1,290 @@
+# Copilot Agent Prompt — Plan 025 Phase 1c: Tech Radar Viewer (visual radar)
+
+> **Usage**: Paste the contents of the **Prompt** section below into GitHub
+> Copilot agent. Everything above the horizontal rule is meta-context for the
+> human; everything below it is the agent instruction.
+>
+> **Runs in parallel with** [025-phase1d-library-detail-page.md](025-phase1d-library-detail-page.md).
+> The only file both tasks edit is `web/admin-ui/src/App.tsx`. See the
+> **Parallel execution** section — keep to the assigned insertion anchors and the
+> two PRs will auto-merge.
+
+**Branch to create**: `feature/025-phase1c-tech-radar-viewer`
+**PR target**: `main`
+**PR title**: `Plan 025 Phase 1c: Tech Radar viewer (visual Zalando radar)`
+
+---
+
+## Prompt
+
+You are implementing **Phase 1c of Plan 025** for the `azure_devops_analyzer`
+repository. The plan is at `.ai/plans/025-bespoke-admin-and-navigation-ui.md`
+("Task C" under *What's next*) — read it first.
+
+You are adding two routes to the **existing** React admin UI at `web/admin-ui/`:
+
+- `/radar` — renders an **actual visual radar** (the circular blip diagram).
+- `/radar/history` — renders the ring-movement timeline as a sortable table.
+
+This is **frontend-only**. Do **NOT** touch anything under `src/`, `tests/`,
+`dashboards/`, or `database/`. The backend endpoints already exist and are
+unchanged.
+
+---
+
+### Renderer: vendored Zalando tech-radar (MIT) — NOT Thoughtworks BYOR
+
+Render the radar with the **MIT-licensed** D3 renderer from
+<https://github.com/zalando/tech-radar> (single file `radar.js`, exposes
+`radar_visualization()`, uses D3 v7).
+
+> **Why Zalando and not Thoughtworks build-your-own-radar:** BYOR is AGPL-3.0,
+> which would copyleft this frontend bundle. The maintainer rejected that.
+> Zalando's radar is the same Thoughtworks-derived visual but MIT — no copyleft.
+> **Do not** substitute BYOR, an iframe to thoughtworks.com, or a plain list.
+
+**Vendoring steps:**
+
+1. Download `radar.js` from a pinned Zalando release (e.g. `release/radar-0.12.js`)
+   into `web/admin-ui/src/vendor/zalando-radar/radar.js`. **Record the exact
+   release/commit** in a comment at the top of the file and **keep its MIT
+   copyright header** intact.
+2. The file is written as a browser global, not an ES module. Lightly adapt it to
+   `export function radar_visualization(config) { ... }` (MIT permits
+   modification). Do not rewrite its drawing logic — only the export seam.
+3. Add `d3` (v7) to `dependencies` and `@types/d3` to `devDependencies` in
+   `web/admin-ui/package.json`. Run `npm install` so `package-lock.json` updates.
+4. Add a `web/admin-ui/THIRD_PARTY_NOTICES.md` (or append if it exists) crediting
+   Zalando tech-radar under MIT with the pinned version.
+
+---
+
+### Backend endpoints (already exist — read-only contract)
+
+**`GET /api/radar`** returns Thoughtworks-format JSON:
+
+```jsonc
+{
+  "documentTitle": "Organization Tech Radar",
+  "quadrants": [ {"name": "Infrastructure"}, {"name": "Platforms"},
+                 {"name": "Tools"}, {"name": "Languages & Frameworks"} ],
+  "rings": [ {"name": "Adopt",  "color": "#00AA00"},
+             {"name": "Trial",  "color": "#00FFFF"},
+             {"name": "Assess", "color": "#FFFF00"},
+             {"name": "Hold",   "color": "#FF0000"} ],
+  "entries": [
+    { "id": 1, "label": "react", "description": "...",
+      "quadrant": "Languages & Frameworks", "ring": "Trial",
+      "isNew": false, "isMoved": true }
+  ],
+  "publication": { "id": 1, "version": "...", "date": "2026-05-25", "published_by": "..." }
+}
+```
+
+When no radar has been published yet, `entries` is `[]` (and there is no
+`publication` key). Handle this — show a "No radar published yet" placeholder,
+**not** a broken/empty chart.
+
+**`GET /api/radar/history`** returns:
+
+```jsonc
+{ "timeline": [
+  { "publication_date": "2026-05-25", "package_name": "react", "ecosystem": "npm",
+    "prior_ring": "Assess", "current_ring": "Trial",
+    "repo_count_delta": 3, "vulnerability_change": 0 }
+] }
+```
+
+---
+
+### Files to create
+
+```
+web/admin-ui/
+  THIRD_PARTY_NOTICES.md                    ← Zalando MIT credit (create or append)
+  src/
+    vendor/zalando-radar/radar.js           ← vendored MIT renderer (ESM-adapted)
+    api/
+      radar.ts                              ← typed client + response types (THIS feature only)
+      radar.test.ts
+    lib/
+      radarMapping.ts                       ← pure: /api/radar response → Zalando config
+      radarMapping.test.ts
+    components/
+      RadarChart.tsx                        ← React wrapper around radar_visualization()
+      RadarChart.test.tsx
+    pages/
+      RadarPage.tsx
+      RadarPage.test.tsx
+      RadarHistoryPage.tsx
+      RadarHistoryPage.test.tsx
+  e2e/
+    radar.spec.ts
+```
+
+> **Note**: put the radar API client + its types in a **new** `src/api/radar.ts`
+> file. Do **not** append to the shared `src/api/client.ts` / `src/api/types.ts`
+> — that keeps this PR conflict-free against the parallel Phase 1d PR.
+
+### Files to modify (minimal, additive)
+
+- `web/admin-ui/package.json` — add `d3` + `@types/d3` (only this task touches it).
+- `web/admin-ui/src/components/Layout.tsx` — add **one** nav link
+  `{ to: '/radar', label: 'Tech Radar' }` to the `navLinks` array (only this task
+  touches it).
+- `web/admin-ui/src/App.tsx` — see **Parallel execution** for the exact anchor.
+
+---
+
+### Data mapping (`src/lib/radarMapping.ts`)
+
+Zalando's `radar_visualization()` uses **numeric** quadrant/ring indices; the API
+uses **names**. Write a pure function `toRadarConfig(api)` that converts:
+
+- `quadrants`: pass through `[{name}]` (4). Placement order is cosmetic.
+- `rings`: pass through `[{name, color}]` indexed 0→3 inner→outer. The API order
+  Adopt / Trial / Assess / Hold already matches (Adopt = innermost = index 0).
+  Pass each ring's `color` through.
+- `entries`: map each blip to
+  `{ label: e.label, quadrant: <index of e.quadrant in quadrants>, ring: <index of e.ring in rings>, moved: e.isNew ? 2 : (e.isMoved ? 1 : 0), active: true }`.
+  (Zalando `moved`: `2` = new, `1` = moved in, `0` = no change, `-1` = moved out.
+  The API gives no moved-out signal, so `-1` is unused.)
+- If a blip's `quadrant`/`ring` name is not found in the arrays, drop it and
+  `console.warn` — never produce `quadrant: -1`.
+
+`RadarChart.tsx` takes the API response (or the mapped config) as a prop, and in a
+`useEffect` calls `radar_visualization()` against a ref'd `<svg id="radar">`.
+Clear the SVG's children on unmount / before re-render so it doesn't double-draw.
+
+---
+
+### Pages
+
+- **`RadarPage.tsx`** — `useQuery` against `getRadar()` (from `api/radar.ts`).
+  Loading + error states. If `entries.length === 0`, render the placeholder.
+  Otherwise render `<RadarChart>`. Show the publication date/version if present.
+- **`RadarHistoryPage.tsx`** — `useQuery` against `getRadarHistory()`. Render a
+  table of the `timeline` rows. Make at least the `publication_date` and
+  `package_name` columns **sortable** (click header toggles asc/desc). Loading +
+  error + empty states.
+
+### Tech stack (locked — match the existing app)
+
+React 18 + Vite 5 + TS (strict) · Tailwind v3 (utility classes only) · TanStack
+Query v5 · React Router v6 · Vitest + `@testing-library/react` · Playwright (e2e).
+Plus `d3` v7 for the radar. No other new runtime deps.
+
+---
+
+### Tests
+
+- **`lib/radarMapping.test.ts`** (the important one): quadrant→index and
+  ring→index conversion; `moved` derivation for new / moved / unchanged blips;
+  colour pass-through; empty `entries`; unknown quadrant/ring name dropped.
+- **`api/radar.test.ts`**: mock `fetch`; assert correct URL + that a non-2xx
+  throws an `Error` with the body text (mirror `src/api/client.ts`'s `request()`).
+- **`pages/RadarPage.test.tsx`**: mock `api/radar.ts`. Assert the empty-state
+  placeholder renders when `entries: []`; assert a populated response mounts the
+  chart (an `<svg>` appears). Assert the error path shows an error message.
+- **`pages/RadarHistoryPage.test.tsx`**: mock the client; assert rows render and
+  that clicking a sortable header reorders them.
+- **`components/RadarChart.test.tsx`**: smoke test — mounts without throwing and
+  emits an `<svg>`. **Do not** assert on D3-computed geometry (jsdom doesn't lay
+  out SVG).
+- **`e2e/radar.spec.ts`**: follow the pattern in the existing `e2e/*.spec.ts`
+  files (mock the API the same way they do). Verify `/radar` shows a radar (or the
+  empty placeholder) and `/radar/history` shows the table.
+
+---
+
+### Parallel execution — `App.tsx` is the only shared file
+
+This task runs **at the same time** as Phase 1d. Both add a route to
+`web/admin-ui/src/App.tsx`. To let git auto-merge, use these **exact anchors**:
+
+- **Import**: add your imports immediately **after** the existing
+  `import HealthPage from './pages/HealthPage'` line:
+  ```tsx
+  import RadarPage from './pages/RadarPage'
+  import RadarHistoryPage from './pages/RadarHistoryPage'
+  ```
+- **Routes**: add yours immediately **after** the existing
+  `<Route path="/health" element={<HealthPage />} />` line:
+  ```tsx
+  <Route path="/radar" element={<RadarPage />} />
+  <Route path="/radar/history" element={<RadarHistoryPage />} />
+  ```
+
+Phase 1d uses different anchors (after `RepositoriesPage` / `/repositories`), so
+the two diffs do not overlap. If your PR merges second and git still flags a
+conflict in `App.tsx`, it is a trivial 2-line resolve — keep both sets of routes.
+
+Do **not** edit `src/api/client.ts`, `src/api/types.ts`, `src/api/client.test.ts`,
+`src/pages/HomePage.tsx`, or any Phase 1d file.
+
+---
+
+### Architecture constraint
+
+`web/admin-ui` code must **never** import from `src/`, `tests/`, or
+`dashboards/`. It talks to the Flask API over HTTP only. If you reach outside
+`web/admin-ui/`, stop — that's wrong.
+
+---
+
+### Out of scope
+
+- Phase 1d (Library detail page) — separate parallel PR.
+- The radar **export** endpoint (`/api/radar/export`) — not part of this phase.
+- Any backend change. The endpoints exist and are correct.
+- Auth, dark mode, i18n, mobile-first layout.
+- A HomePage tile for the radar — the Layout nav link is the entry point.
+
+---
+
+### Acceptance checklist (reviewer will verify)
+
+- [ ] `/radar` renders the **visual** Zalando radar (circular blip diagram), not a list/iframe
+- [ ] Empty publication (`entries: []`) shows a placeholder, not a broken chart
+- [ ] `/radar/history` renders a sortable timeline table
+- [ ] "Tech Radar" nav link appears in `Layout.tsx`
+- [ ] `radar.js` is vendored with its MIT header + pinned version; `THIRD_PARTY_NOTICES.md` credits it
+- [ ] `radarMapping.ts` is a pure, unit-tested function (name→index, `moved` derivation, empty/unknown handling)
+- [ ] `d3` added to `package.json`; `package-lock.json` regenerated
+- [ ] New API client lives in `src/api/radar.ts` (shared `client.ts`/`types.ts` untouched)
+- [ ] `App.tsx` edits use the assigned anchors (after `/health`)
+- [ ] No files changed under `src/`, `tests/`, `dashboards/`, or `database/`
+- [ ] `npm run typecheck`, `npm run test -- --run`, `npm run build`, and `npm run e2e` all exit 0 in `web/admin-ui/`
+
+---
+
+## ACCEPTANCE — DO NOT STOP UNTIL CI IS GREEN
+
+This is non-negotiable. Previous Copilot agents on this project have declared work
+done while CI was red, costing the maintainer 2+ feedback rounds per task.
+
+1. **Before pushing**, from `web/admin-ui/` run locally and get all four green:
+   `npm run typecheck` · `npm run test -- --run` · `npm run build` · `npm run e2e`
+   (run `npx playwright install chromium` first if needed).
+2. After pushing and opening the PR, run: `gh pr checks <PR#> --watch`.
+3. If any required check fails:
+   1. `gh run view <run-id> --log-failed` to read the failure.
+   2. Fix the **root cause**. Do **NOT** `--no-verify`, skip/weaken tests, or
+      delete assertions to make CI pass.
+   3. Commit, push, repeat from step 2.
+4. Required check: the **Frontend CI** workflow (`.github/workflows/frontend.yml`),
+   which runs typecheck + test + build + Playwright e2e on `web/admin-ui/**`.
+5. Only declare done when: all required checks are green, the PR has no merge
+   conflicts, and the final PR comment links to the green check run.
+
+If you cannot get CI green after 3 attempts, stop and post a comment explaining
+what you tried and what's blocking. If the Zalando `radar.js` proves hard to
+adapt to ESM, **stop and ask** before substituting a different renderer — the MIT
+licensing is the whole reason it was chosen.
+
+---
+
+### Estimated size
+
+~3–4 days. The vendored-renderer ESM seam and the name→index mapping are the
+two fiddly parts — get `radarMapping.test.ts` green first, then wire the chart.

--- a/.ai/prompts/025-phase1d-library-detail-page.md
+++ b/.ai/prompts/025-phase1d-library-detail-page.md
@@ -1,0 +1,250 @@
+# Copilot Agent Prompt — Plan 025 Phase 1d: Library Detail Page
+
+> **Usage**: Paste the contents of the **Prompt** section below into GitHub
+> Copilot agent. Everything above the horizontal rule is meta-context for the
+> human; everything below it is the agent instruction.
+>
+> **Runs in parallel with** [025-phase1c-tech-radar-viewer.md](025-phase1c-tech-radar-viewer.md).
+> The only file both tasks edit is `web/admin-ui/src/App.tsx`. See the
+> **Parallel execution** section — keep to the assigned insertion anchors and the
+> two PRs will auto-merge.
+
+**Branch to create**: `feature/025-phase1d-library-detail-page`
+**PR target**: `main`
+**PR title**: `Plan 025 Phase 1d: Library detail page`
+
+---
+
+## Prompt
+
+You are implementing **Phase 1d of Plan 025** for the `azure_devops_analyzer`
+repository. The plan is at `.ai/plans/025-bespoke-admin-and-navigation-ui.md`
+("Task D" under *What's next*) — read it first.
+
+You are adding **one route** to the **existing** React admin UI at
+`web/admin-ui/`:
+
+- `/library/:ecosystem/:name` — a detail page for a single library/package:
+  metadata + CVE list + adoption-by-team + per-repo usage.
+
+This is **frontend-only**. Do **NOT** touch anything under `src/`, `tests/`,
+`dashboards/`, or `database/`. The backend endpoint already exists and is
+unchanged. It coexists with the Grafana `library-detail-deep-dive.json` dashboard
+— both stay; Phase 3's data links still point at the Grafana version.
+
+---
+
+### Backend endpoint (already exists — read-only contract)
+
+**`GET /api/packages/library/<name>/<ecosystem>`** — note the path order is
+**name first, then ecosystem**. Returns:
+
+```jsonc
+{
+  "metadata": { "package_name": "react", "ecosystem": "npm",
+                "latest_version": "18.3.1", "is_eol": false, "eol_date": null },
+  "cves": [
+    { "cve_id": "CVE-2024-1234", "severity": "HIGH", "summary": "...",
+      "fixed_in_version": "18.3.0", "published_date": "2024-03-01",
+      "exposed_repo_count": 4 }
+  ],
+  "usage": [
+    { "repo_id": "...", "team_name": "Payments", "version": "18.2.0",
+      "has_known_vulnerabilities": true }
+  ],
+  "by_team": [
+    { "team_name": "Payments", "repo_count": 6, "exposed_repos": 2,
+      "versions_in_use": ["18.2.0", "18.3.1"] }
+  ]
+}
+```
+
+If the package does not exist, the endpoint returns **HTTP 404** with
+`{"status": "error", "message": "Package not found"}`. Handle this with a clean
+"Package not found" message, not a crash.
+
+> **Route vs endpoint param order — do not get this wrong.** The React route is
+> `/library/:ecosystem/:name` (ecosystem first in the URL), but the API path is
+> `/api/packages/library/<name>/<ecosystem>` (name first). Read both
+> `useParams()` values and pass them to the client in the **API's** order.
+
+---
+
+### Files to create
+
+```
+web/admin-ui/
+  src/
+    api/
+      library.ts                  ← typed client + response types (THIS feature only)
+      library.test.ts
+    pages/
+      LibraryDetailPage.tsx
+      LibraryDetailPage.test.tsx
+  e2e/
+    library.spec.ts
+```
+
+> **Note**: put the library API client + its types in a **new** `src/api/library.ts`
+> file. Do **not** append to the shared `src/api/client.ts` / `src/api/types.ts`
+> — that keeps this PR conflict-free against the parallel Phase 1c PR.
+
+### Files to modify (minimal, additive)
+
+- `web/admin-ui/src/App.tsx` — add **one** route. See **Parallel execution** for
+  the exact anchor. This is the only shared file.
+
+You do **not** need to modify `Layout.tsx`, `HomePage.tsx`, or `package.json`.
+(`/library/:ecosystem/:name` is a parametric leaf route reached by direct URL or a
+future drill-down link — a nav link/tile would need params it doesn't have. A
+dedicated entry point is explicitly a future enhancement; see Out of scope.)
+
+---
+
+### Page (`LibraryDetailPage.tsx`)
+
+- Read `ecosystem` and `name` from `useParams()`.
+- `useQuery` against `getLibraryDetail(name, ecosystem)` from `api/library.ts`.
+- States: loading, error (generic 5xx), **not-found** (404 → "Package not found"),
+  and success.
+- On success render four sections:
+  1. **Header / metadata** — package name, ecosystem, latest version, and an
+     EOL badge when `is_eol` is true (show `eol_date` if present).
+  2. **CVEs** — table of `cves` (cve_id, severity, summary, fixed_in_version,
+     published_date, exposed_repo_count). Empty → "No known CVEs".
+  3. **Adoption by team** — table of `by_team` (team_name, repo_count,
+     exposed_repos, versions_in_use joined as a comma list).
+  4. **Per-repo usage** — table of `usage` (repo_id, team_name, version, a
+     "vulnerable" indicator when `has_known_vulnerabilities`).
+
+Use Tailwind utility classes; match the visual style of the existing
+`RepositoriesPage.tsx` (tables, badges, spacing).
+
+### Tech stack (locked — match the existing app)
+
+React 18 + Vite 5 + TS (strict) · Tailwind v3 (utility classes only) · TanStack
+Query v5 · React Router v6 · Vitest + `@testing-library/react` · Playwright (e2e).
+**No new runtime dependencies.**
+
+---
+
+### API client (`src/api/library.ts`)
+
+Export one typed function plus its response types:
+
+```typescript
+// GET /api/packages/library/<name>/<ecosystem>
+export async function getLibraryDetail(name: string, ecosystem: string): Promise<LibraryDetail>
+```
+
+`encodeURIComponent` both path segments. Throw an `Error` with the response body
+text on non-2xx (mirror the `request()` helper in `src/api/client.ts`), but the
+page must be able to distinguish a 404 from other errors (e.g. check the thrown
+message or expose the status) so it can show "Package not found".
+
+---
+
+### Tests
+
+- **`api/library.test.ts`**: mock `fetch`; assert the request URL is
+  `/api/packages/library/<name>/<ecosystem>` in the **correct order**; assert the
+  parsed body returns; assert non-2xx throws; assert 404 is distinguishable.
+- **`pages/LibraryDetailPage.test.tsx`**: mock `api/library.ts`. Cover loading,
+  the populated happy path (all four sections render with sample data), the empty
+  `cves` case ("No known CVEs"), the 404 → "Package not found" path, and a generic
+  error path. Assert the EOL badge appears when `is_eol` is true.
+- **`e2e/library.spec.ts`**: follow the pattern in the existing `e2e/*.spec.ts`
+  files (mock the API the same way they do). Navigate to a
+  `/library/npm/some-package` URL and assert the metadata header renders.
+
+---
+
+### Parallel execution — `App.tsx` is the only shared file
+
+This task runs **at the same time** as Phase 1c. Both add a route to
+`web/admin-ui/src/App.tsx`. To let git auto-merge, use these **exact anchors**:
+
+- **Import**: add your import immediately **after** the existing
+  `import RepositoriesPage from './pages/RepositoriesPage'` line:
+  ```tsx
+  import LibraryDetailPage from './pages/LibraryDetailPage'
+  ```
+- **Route**: add yours immediately **after** the existing
+  `<Route path="/repositories" element={<RepositoriesPage />} />` line:
+  ```tsx
+  <Route path="/library/:ecosystem/:name" element={<LibraryDetailPage />} />
+  ```
+
+Phase 1c uses different anchors (after `HealthPage` / `/health`), so the two diffs
+do not overlap. If your PR merges second and git still flags a conflict in
+`App.tsx`, it is a trivial resolve — keep both sets of routes.
+
+Do **not** edit `src/api/client.ts`, `src/api/types.ts`, `src/api/client.test.ts`,
+`src/components/Layout.tsx`, `src/pages/HomePage.tsx`, `package.json`, or any
+Phase 1c file.
+
+---
+
+### Architecture constraint
+
+`web/admin-ui` code must **never** import from `src/`, `tests/`, or
+`dashboards/`. It talks to the Flask API over HTTP only. If you reach outside
+`web/admin-ui/`, stop — that's wrong.
+
+---
+
+### Out of scope
+
+- Phase 1c (Tech Radar viewer) — separate parallel PR.
+- An entry point for the page (nav link, HomePage tile, or a `/library` search
+  index). The page is reached by direct URL / future drill-down for this PR;
+  a "Library Browser" entry is a later enhancement per the plan.
+- Any backend change. The endpoint exists and is correct.
+- Editing the Grafana `library-detail-deep-dive.json` dashboard (it stays).
+- Auth, dark mode, i18n, mobile-first layout.
+
+---
+
+### Acceptance checklist (reviewer will verify)
+
+- [ ] `/library/:ecosystem/:name` renders metadata, CVEs, adoption-by-team, and per-repo usage
+- [ ] URL params (`ecosystem`, `name`) are passed to the API in the correct order (name, ecosystem)
+- [ ] EOL badge shows when `is_eol` is true; "No known CVEs" shows when `cves` is empty
+- [ ] 404 from the API renders a clean "Package not found", not a crash
+- [ ] New API client lives in `src/api/library.ts` (shared `client.ts`/`types.ts` untouched)
+- [ ] `App.tsx` edits use the assigned anchors (after `/repositories`)
+- [ ] No new runtime dependencies added
+- [ ] No files changed under `src/`, `tests/`, `dashboards/`, or `database/`
+- [ ] `npm run typecheck`, `npm run test -- --run`, `npm run build`, and `npm run e2e` all exit 0 in `web/admin-ui/`
+
+---
+
+## ACCEPTANCE — DO NOT STOP UNTIL CI IS GREEN
+
+This is non-negotiable. Previous Copilot agents on this project have declared work
+done while CI was red, costing the maintainer 2+ feedback rounds per task.
+
+1. **Before pushing**, from `web/admin-ui/` run locally and get all four green:
+   `npm run typecheck` · `npm run test -- --run` · `npm run build` · `npm run e2e`
+   (run `npx playwright install chromium` first if needed).
+2. After pushing and opening the PR, run: `gh pr checks <PR#> --watch`.
+3. If any required check fails:
+   1. `gh run view <run-id> --log-failed` to read the failure.
+   2. Fix the **root cause**. Do **NOT** `--no-verify`, skip/weaken tests, or
+      delete assertions to make CI pass.
+   3. Commit, push, repeat from step 2.
+4. Required check: the **Frontend CI** workflow (`.github/workflows/frontend.yml`),
+   which runs typecheck + test + build + Playwright e2e on `web/admin-ui/**`.
+5. Only declare done when: all required checks are green, the PR has no merge
+   conflicts, and the final PR comment links to the green check run.
+
+If you cannot get CI green after 3 attempts, stop and post a comment explaining
+what you tried and what's blocking.
+
+---
+
+### Estimated size
+
+~2–3 days. Mostly a data-rendering page over one endpoint. The two things to get
+right: the **name/ecosystem param order** and the **404 → "Package not found"**
+distinction.

--- a/.ai/prompts/README.md
+++ b/.ai/prompts/README.md
@@ -13,6 +13,32 @@ Ready-to-paste prompts for delegating work to GitHub Copilot agents (or equivale
 
 The wave prompts above remain in this folder as reference templates for drafting future agent prompts (esp. the CI-green acceptance block at the end of each).
 
+## Wave 3 — Plan 025 Phase 1c + 1d (✅ run in parallel)
+
+These two close out the remaining deferred phases of Plan 025. They are
+**designed to run at the same time**: each does most of its work in new,
+feature-scoped files and gets its own `src/api/*.ts` module instead of appending
+to the shared `client.ts`/`types.ts`.
+
+| Prompt | Plan | Description |
+|---|---|---|
+| [025-phase1c-tech-radar-viewer.md](025-phase1c-tech-radar-viewer.md) | Plan 025 Phase 1c | `/radar` + `/radar/history` — visual radar via the MIT-licensed Zalando tech-radar (D3), plus history table |
+| [025-phase1d-library-detail-page.md](025-phase1d-library-detail-page.md) | Plan 025 Phase 1d | `/library/:ecosystem/:name` — library detail page over `GET /api/packages/library/<name>/<ecosystem>` |
+
+**Parallel-safety contract:** the *only* file both PRs edit is
+`web/admin-ui/src/App.tsx`. Each prompt pins a **different insertion anchor**
+(1c after the `/health` route; 1d after the `/repositories` route) so git
+auto-merges. 1c additionally (and exclusively) touches `Layout.tsx` and
+`package.json` (adds `d3`); 1d touches no other shared file. Whichever PR merges
+second should auto-merge; if `App.tsx` ever conflicts it's a 2-line resolve (keep
+both route sets). Merge order doesn't matter.
+
+> **Licensing note for 1c:** the renderer is Zalando tech-radar (**MIT**), *not*
+> Thoughtworks build-your-own-radar (**AGPL-3.0**) — the swap was a deliberate
+> decision to keep copyleft off the frontend bundle. The prompt forbids
+> substituting BYOR. See `.ai/plans/025-bespoke-admin-and-navigation-ui.md`
+> Task C and `PROGRESS.md` (2026-05-25).
+
 ## Wave 2 (drafting on demand)
 
 - **Plan 020 Component 2** (live-API nightly monitoring) — ✅ merged 2026-05-03 in [PR #90](https://github.com/stickleprojects/azure_devops_analyzer/pull/90). Carved out of Wave 1 because it required provisioning live API tokens manually. Plan 020 is now fully complete.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,123 @@
 
 ---
 
+## Session: 2026-05-25 — Plan 025 Task C: swap radar renderer BYOR → Zalando (AGPL concern) (docs-only)
+
+### Summary
+
+The user raised a licensing concern about using Thoughtworks build-your-own-radar
+(BYOR) for the Phase 1c visual radar, because BYOR is **AGPL-3.0** and vendoring
+it would copyleft the bundled `admin-ui` frontend. Swapped the renderer to the
+**MIT-licensed** [Zalando tech-radar](https://github.com/zalando/tech-radar) —
+the same Thoughtworks-derived circular visual, no copyleft. Supersedes the BYOR
+decision made earlier the same day (entry below).
+
+### Decision and why
+
+- **Chosen:** Zalando tech-radar (MIT, © 2017–2025 Zalando SE), D3 v7, single
+  `radar.js` file. It is explicitly based on the Thoughtworks radar concept, so
+  the visual is equivalent.
+- **Rejected:** Thoughtworks BYOR (AGPL-3.0). Copyleft on the frontend bundle is
+  unacceptable to the user even for an internal `localhost`-only tool; a
+  permissive licence removes the obligation and the need for sign-off entirely.
+- **Bonus:** Zalando is a single file (vs BYOR's webpack app), so integration is
+  simpler — effort dropped from ~4–5 to ~3–4 days.
+
+### Data-format note (for the implementer)
+
+Zalando uses **numeric** quadrant/ring indices; `/api/radar` returns **names**.
+The mapping function converts name→index (quadrant order cosmetic; rings
+Adopt/Trial/Assess/Hold = 0→3 inner→outer, already aligned) and derives Zalando's
+`moved` field: `isNew` → `2`, else `isMoved` → `1`, else `0`. Entry shape:
+`{ label, quadrant: idx, ring: idx, moved, active: true }`.
+
+### What Was Done
+
+- `.ai/plans/025-bespoke-admin-and-navigation-ui.md` — Task C + Phase 1c scope
+  bullet rewritten for Zalando; added a "Why Zalando, not BYOR" note; replaced the
+  AGPL/ webpack Risks rows with MIT-resolved + single-file rows; effort → ~3–4 days.
+- Memory `web-ui-decision.md` — radar decision updated to Zalando + AGPL rationale.
+
+### Validation
+
+- Docs-only; no tests run. No code touched.
+
+---
+
+## Session: 2026-05-25 — Plan 025 Task C scope change: visual BYOR radar (docs-only) — SUPERSEDED (see entry above; BYOR dropped over AGPL)
+
+### Summary
+
+At the user's request, changed Plan 025 Phase 1c (Task C) from "render the radar
+JSON as a categorised blip list" to "render an **actual visual radar** (the
+circular blip diagram) using the Thoughtworks open-source D3 build-your-own-radar
+(BYOR) renderer." Backend is unchanged — `GET /api/radar` already serves
+canonical BYOR-format JSON, so this is purely a frontend rendering decision.
+
+### Key findings driving the plan text
+
+- BYOR is **AGPL-3.0** (verified via the repo LICENSE). Vendoring it copylefts
+  the bundled `admin-ui` frontend. Acceptable for an internal `localhost`-only
+  tool but must be acknowledged (AGPL notice, source kept available, user
+  sign-off). Flagged as a must-address-before-merge item + a Risks-table row.
+- BYOR is a webpack app, not a clean npm package → integration is "vendor the
+  `graphing/` + `models/` D3 modules, pin a commit, wrap in a thin React
+  component driven by a unit-tested data-mapping function."
+- D3/SVG renders poorly under jsdom → test plan shifts to hard-testing the pure
+  mapping function + a mount smoke test + Playwright e2e for the visual.
+
+### What Was Done
+
+- `.ai/plans/025-bespoke-admin-and-navigation-ui.md` — rewrote Task C ("What's
+  next") and the Phase 1c scope bullet for the visual radar; bumped the 1c effort
+  estimate to ~4–5 days; added two BYOR rows (AGPL + webpack-app friction) to the
+  Risks table.
+- Memory `web-ui-decision.md` — recorded the visual-BYOR-radar + AGPL decision.
+
+### Validation
+
+- Docs-only; no tests run. No code touched.
+
+---
+
+## Session: 2026-05-25 — Plan 025 status reconciliation (docs-only)
+
+### Summary
+
+Reviewed Plan 025 state against the code and git history at the user's request
+("I think plan 025 is mostly complete now"). Confirmed it: Phases 2, 3, 1a, 1b
+are all merged; only the two deferred optional phases (1c Tech Radar viewer, 1d
+Library detail page) remain. Refreshed the stale docs to match. No code changed.
+
+### Verification
+
+- `web/admin-ui/src/App.tsx` exposes routes `/`, `/extraction`, `/health`,
+  `/repositories` only — no `/radar` or `/library`, confirming 1c/1d unbuilt.
+- Git log confirms the merged PRs: Phase 2 #85 (+ extraction-health gap fix #103),
+  Phase 3 #94, Phase 1a #96, Phase 1b #104.
+
+### Decision
+
+- Plan kept **IN PROGRESS** (user's call), **not** moved to `.ai/plans/completed/`.
+  1c/1d stay tracked inside the plan as the only remaining work. Both
+  dependencies (Plans 022 and 021) are merged, so either is pickable now.
+
+### What Was Done
+
+- `.ai/plans/025-bespoke-admin-and-navigation-ui.md` — status line now reads
+  "IN PROGRESS (mostly complete) … Phase 1c/1d deferred — the only remaining
+  work"; rewrote the "What's next" section (Tasks A & B marked done, added a
+  Task D agent entry point for Phase 1d alongside the existing Task C for 1c).
+- Memory: `MEMORY.md` moved Plan 025 to an accurate "mostly complete" summary
+  and refreshed the Web UI active-work line; `web-ui-decision.md` Wave 2
+  candidates flipped to "shipped" with the 1c/1d remainder noted.
+
+### Validation
+
+- Docs-only; no tests run. JSON/code untouched.
+
+---
+
 ## Session: 2026-05-25 — Plan 025 Phase 1b implementation
 
 ### Summary


### PR DESCRIPTION
@
## Summary

Docs-only update to **Plan 025 (Bespoke Admin & Navigation UI)**. No application code touched.

1. **Status reconciliation** — verified against code + git that Phases 2, 3, 1a, 1b are all merged; only the deferred optional phases **1c (Tech Radar viewer)** and **1d (Library detail page)** remain. Refreshed the stale "Whats next" section (it claimed two tasks remained when both were done). Plan kept **IN PROGRESS** (not moved to `completed/`).

2. **Phase 1c → real visual radar, with an MIT renderer** — changed Task C from "render the radar JSON as a list" to "render an actual circular radar". After the maintainer flagged a licensing concern, swapped the renderer from Thoughtworks build-your-own-radar (**AGPL-3.0**, would copyleft the frontend bundle) to the **MIT-licensed** [Zalando tech-radar](https://github.com/zalando/tech-radar) — same Thoughtworks-derived visual, no copyleft. Decision + rationale recorded in the plan, `PROGRESS.md`, and the Risks table.

3. **Parallel coding-agent prompts** — added ready-to-paste Copilot prompts for the two remaining phases, designed to run **at the same time**:
   - `025-phase1c-tech-radar-viewer.md`
   - `025-phase1d-library-detail-page.md`

   Parallel-safety: each task gets its own `src/api/*.ts` module (no shared `client.ts`/`types.ts` edits); the only common file is `App.tsx`, where each prompt pins a **different insertion anchor** so git auto-merges. Registered both under a new Wave 3 section in the prompts README.

## Files changed
- `.ai/plans/025-bespoke-admin-and-navigation-ui.md`
- `PROGRESS.md`
- `.ai/prompts/025-phase1c-tech-radar-viewer.md` (new)
- `.ai/prompts/025-phase1d-library-detail-page.md` (new)
- `.ai/prompts/README.md`

## Test plan
Docs-only; no tests run, no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@