### PR TITLE
fix(test): mount views.sql into test-migrations so it can't go stale

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -70,6 +70,7 @@ services:
     volumes:
       # Mount schema and migrations at runtime for development (no rebuild needed)
       - ./database/schema.sql:/migrations/schema.sql:ro
+      - ./database/views.sql:/migrations/views.sql:ro
       - ./database/migrations:/migrations/migrations:ro
     depends_on:
       test-db:


### PR DESCRIPTION
## Summary
- The `test-migrations` service in `docker-compose.test.yml` mounted `schema.sql` and `migrations/` as live volumes but **baked `views.sql` into the image** (`Dockerfile.migrations` `COPY database/views.sql`).
- Migration `014_normalise_packages.sql` is the **only** migration that runs `\ir ../views.sql`. With a cached image, that include pulls a **frozen** copy of `views.sql`, so after a `git pull` into an existing clone (where `docker compose run` reuses the old image) migration 014 runs stale views against the freshly-renamed schema and **aborts silently** — migrations 010–013 succeed, then 014 dies with no clear error.
- Fix: mount `./database/views.sql:/migrations/views.sql:ro` so it stays current like the other SQL files. `\ir ../views.sql` resolves to `/migrations/views.sql`, so the mount makes the include always match the checkout and removes the stale-image failure mode.

## Test plan
- [x] `wc -l /migrations/views.sql` inside the container shows the live host file (1541 lines), confirming the mount overrides the baked layer
- [x] `docker compose -f docker-compose.test.yml run --rm test-migrations` applies all 11 migrations (incl. 014) and reapplies views successfully
- [ ] CI `tests.yml` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)