### PR TITLE
feat(test): add --force-build flag to run-tests-docker

### DIFF
--- a/docs/03-operations/docker-setup.md
+++ b/docs/03-operations/docker-setup.md
@@ -99,7 +99,9 @@ The test stack behavior:
 - Runs post-integration DB invariant checks via `scripts/verify-extraction.sh`
 - Cleans up resources when finished
 
-The `test-runner` service in `docker-compose.test.yml` bind-mounts `./scripts`, `./src`, `./tests`, and `./database` into `/app`, so shell and Python changes in those directories apply on the next run without an image rebuild. Rebuild (`docker compose -f docker-compose.test.yml build test-runner`) is only required when `Dockerfile` or `requirements.txt` changes.
+The `test-runner` service in `docker-compose.test.yml` bind-mounts `./scripts`, `./src`, `./tests`, and `./database` into `/app`, so shell and Python changes in those directories apply on the next run without an image rebuild. A rebuild is only required when a *baked* (non-mounted) input changes — `Dockerfile` / `requirements.txt` for `test-runner`, or `Dockerfile.migrations` / `docker/scripts/run_migrations.sh` for `test-migrations`.
+
+Because `docker compose run` reuses the existing image, after a `git pull` or branch switch the baked content can drift from source and fail tests in confusing ways (the classic symptom is migrations dying silently at `014`). Rather than tracking which inputs changed, just run `./scripts/run-tests-docker.sh --force-build` after pulling — it rebuilds `test-migrations` and `test-runner` (cache-aware, so fast when nothing changed). The manual equivalent is `docker compose -f docker-compose.test.yml build test-migrations test-runner`.
 
 ## Troubleshooting
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,7 +19,13 @@ Runs tests in Docker with a clean database. **Now matches CI exactly** - runs te
 ./scripts/run-tests-docker.sh tests/unit/              # Run specific test path
 ./scripts/run-tests-docker.sh --live-api               # Run live API tests
 ./scripts/run-tests-docker.sh --keep-db                # Keep database for debugging
+./scripts/run-tests-docker.sh --force-build            # Rebuild images first (after a git pull / branch switch)
 ```
+
+> **After a `git pull` or branch switch, run with `--force-build`.** `docker compose run`
+> reuses the existing image, so the baked migration runner script or Python deps can drift
+> from source and fail tests in confusing ways (the classic symptom is migrations dying
+> silently at `014`). `--force-build` is cache-aware, so it's fast when nothing actually changed.
 
 **What it does (matches CI exactly):**
 

--- a/scripts/run-tests-docker.sh
+++ b/scripts/run-tests-docker.sh
@@ -11,6 +11,7 @@
 #   ./scripts/run-tests-docker.sh --live-api   # Run only live API tests
 #   ./scripts/run-tests-docker.sh <test_path>  # Run specific test file or pattern
 #   ./scripts/run-tests-docker.sh --keep-db    # Keep database for debugging
+#   ./scripts/run-tests-docker.sh --force-build # Rebuild images first (after a git pull)
 #   ./scripts/run-tests-docker.sh --help       # Show help
 #
 # Environment Variables:
@@ -32,6 +33,7 @@ COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.test.yml"
 RESULTS_DIR="${PROJECT_ROOT}/test-results"
 KEEP_DB=false
 RUN_LIVE_API=false
+FORCE_BUILD=false
 TEST_PATH=""
 ENV_FILE="${PROJECT_ROOT}/.env"
 RESOLVED_ENV_FILE="${PROJECT_ROOT}/.env.resolved"
@@ -80,6 +82,12 @@ OPTIONS:
     --live-api      Run live API tests (tests marked with @pytest.mark.live_api)
                     Includes both GitHub and Azure DevOps platform tests
     --keep-db       Keep test database after run (for debugging)
+    --force-build   Rebuild the test images before running. Use this after a
+                    git pull or branch switch: 'docker compose run' otherwise
+                    reuses the existing image, so a stale baked migration runner
+                    or outdated Python deps can fail tests in confusing ways
+                    (e.g. migrations dying silently at 014). Cache-aware, so it
+                    is fast when nothing actually changed.
     --no-cleanup    Don't clean up containers after run
     --help          Show this help message
 
@@ -89,6 +97,9 @@ EXAMPLES:
 
     # Run specific test file
     $0 tests/unit/extractors/test_cache.py
+
+    # Rebuild images first (do this after a git pull or branch switch)
+    $0 --force-build
 
     # Run only live API tests for both GitHub and Azure DevOps
     $0 --live-api
@@ -172,6 +183,18 @@ build_junit_xml_path() {
     echo "/app/test-results/junit-${safe_suffix}.xml"
 }
 
+# Rebuild the locally-built images (test-migrations, test-runner) before tests.
+# `docker compose run` reuses an existing image, so after a git pull the baked
+# content (migration runner script, Python deps) can drift from source and fail
+# in confusing ways. This is a cache-aware build: a near no-op when nothing
+# changed, a real rebuild of the affected layers when a COPYed file did change.
+force_build_images() {
+    log_info "Rebuilding test images (--force-build)..."
+    docker compose --env-file "$RESOLVED_ENV_FILE" -f "$COMPOSE_FILE" build test-migrations test-runner
+    log_success "Test images rebuilt"
+    echo
+}
+
 # =============================================================================
 # Parse Arguments
 # =============================================================================
@@ -185,6 +208,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --keep-db)
             KEEP_DB=true
+            shift
+            ;;
+        --force-build)
+            FORCE_BUILD=true
             shift
             ;;
         --no-cleanup)
@@ -248,6 +275,16 @@ echo
 # =============================================================================
 # Change to project root so docker-compose volume paths resolve correctly
 cd "$PROJECT_ROOT"
+
+if [ "$FORCE_BUILD" = true ]; then
+    force_build_images
+else
+    log_info "Tip: re-run with --force-build to rebuild the test images first."
+    log_info "     Do this after a git pull or branch switch — otherwise a stale baked"
+    log_info "     migration runner or outdated Python deps can fail tests in confusing"
+    log_info "     ways. It's cache-aware, so it's fast when nothing actually changed."
+    echo
+fi
 
 start_test_db_and_migrations
 


### PR DESCRIPTION
## Summary

After a `git pull` or branch switch, `docker compose run` reuses the existing image, so the baked migration runner script (`docker/scripts/run_migrations.sh`) or Python deps (`requirements.txt`) can drift from source and fail tests in confusing ways — the classic symptom being migrations dying silently at `014`.

This adds an explicit, predictable escape hatch rather than trying to auto-detect staleness:

- **`--force-build` flag** on `run-tests-docker.sh` — rebuilds `test-migrations` and `test-runner` before the run. Cache-aware, so it's a near no-op when nothing changed and a real rebuild of the affected layers when a COPYed file's content changed.
- **Reminder tip** printed when `--force-build` is *not* passed, so the user remembers it exists and when to use it.
- **Docs** updated in `scripts/README.md` and `docs/03-operations/docker-setup.md` to name the flag and the migration-014 symptom.

### Why not auto-detect staleness?

An mtime-based heuristic (image `.Created` vs. baked-input mtime) was prototyped and rejected: `git checkout` / branch switch rewrites files to "now" even when the resulting content is identical to what's already baked, producing **sticky false positives** (a cache-aware rebuild of unchanged content doesn't refresh the image's `.Created`, so it re-prompts every run). An explicit flag is always-correct-when-used; the cost is the user remembering, which the tip + docs cover.

## Test plan

- [x] `bash -n scripts/run-tests-docker.sh` — syntax clean
- [x] `--help` renders the new flag in OPTIONS and EXAMPLES
- [ ] `./scripts/run-tests-docker.sh --force-build` rebuilds both images then runs the suite green
- [ ] `./scripts/run-tests-docker.sh` (no flag) prints the reminder tip and runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)