### PR TITLE
fix(admin-ui): bump @playwright/test to fix HIGH CVE (GHSA-7mvr-c777-76hp)

### DIFF
--- a/web/admin-ui/package-lock.json
+++ b/web/admin-ui/package-lock.json
@@ -15,7 +15,7 @@
         "react-router-dom": "^6.23.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.44.0",
+        "@playwright/test": "^1.55.1",
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
@@ -973,19 +973,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
-      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.44.0"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -4085,35 +4085,35 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.44.0"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/web/admin-ui/package.json
+++ b/web/admin-ui/package.json
@@ -19,7 +19,7 @@
     "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.44.0",
+    "@playwright/test": "^1.55.1",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",


### PR DESCRIPTION
## Summary

Phase 1 of the admin-ui Dependabot triage — clears the only **HIGH** alert.

- Bump `@playwright/test` `^1.44.0 → ^1.55.1` (resolves to **1.60.0**). Fixes **GHSA-7mvr-c777-76hp**: Playwright `< 1.55.1` downloads browser binaries without verifying the SSL certificate.
- devDependency, e2e-only, non-breaking within the `1.x` line.
- Lockfile diff is scoped to the playwright tree (`@playwright/test`, `playwright`, `playwright-core`).

The two remaining **MEDIUM** alerts on the admin UI — vite path traversal (GHSA-4w7w-66w2-5vf9) and esbuild dev-server CORS (GHSA-67mh-4wv8-2f99) — require a breaking **vite 5 → 6** upgrade (no 5.x patch exists; vite 6.4.2 also pulls esbuild ≥ 0.25.0, clearing both). That work is scoped in a separate Phase 2 plan and PR.

## Test plan

- [x] `npm run typecheck` (tsc --noEmit) — passes
- [x] `npm run build` (vite build) — passes (still vite 5.4.21, untouched)
- [x] `npm audit` — HIGH gone; only the Phase 2 vite/esbuild moderate chain remains
- [ ] `npm run e2e` (Playwright) — not run locally (needs browser binaries + a running app); CI/manual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)