### PR TITLE
docs(plan-026): mark vite 6 upgrade COMPLETE and log close-out

### DIFF
--- a/.ai/plans/completed/026-admin-ui-vite6-dependency-upgrade.md
+++ b/.ai/plans/completed/026-admin-ui-vite6-dependency-upgrade.md
@@ -1,6 +1,14 @@
 # Plan 026: Admin UI vite 6 Upgrade (clear remaining MEDIUM Dependabot alerts)
 
-## Status: READY — pick up next session (2026-05-29+)
+## Status: COMPLETE ✅ (PR #117, merged 2026-05-31)
+
+All acceptance criteria met. `vite@6.4.2`, `esbuild@0.25.12`, `vitest@3.2.4`,
+`@vitejs/plugin-react@4.7.0` (kept 4.x). A new transitive advisory surfaced
+during the upgrade — `ws@8.20.0` (GHSA-58qx-3vcg-4xpx) — and was cleared in-range
+to `8.21.0` via `npm audit fix` (no `--force`). `npm audit` → 0 vulnerabilities.
+typecheck / 78 unit tests (vitest 3, no breakage) / build / 15 Playwright e2e all
+pass locally and in CI. Dependabot alerts #1, #3, and the new ws alert all
+auto-closed on merge — repo now has **0 open alerts**.
 
 **Implements**: Phase 2 of the `web/admin-ui` Dependabot remediation — upgrade
 `vite` 5 → 6 so the two remaining **MEDIUM** alerts close. Phase 1 (the HIGH
@@ -90,12 +98,12 @@ npm run e2e          # Playwright (needs browsers + preview server)
 
 ## Acceptance criteria
 
-- [ ] `npm audit` in `web/admin-ui/` reports **0 vulnerabilities**.
-- [ ] `vite ≥ 6.4.2`, `esbuild ≥ 0.25.0`, `vitest ≥ 3.2.4` resolved in the lockfile.
-- [ ] `@vitejs/plugin-react` still on 4.x.
-- [ ] `npm run typecheck`, `npm run test`, `npm run build` all pass.
-- [ ] `npm run e2e` passes (or is explicitly noted as verified in CI).
-- [ ] Dependabot alerts **#1 (esbuild)** and **#3 (vite)** auto-close once merged to `main`.
+- [x] `npm audit` in `web/admin-ui/` reports **0 vulnerabilities**.
+- [x] `vite ≥ 6.4.2`, `esbuild ≥ 0.25.0`, `vitest ≥ 3.2.4` resolved in the lockfile.
+- [x] `@vitejs/plugin-react` still on 4.x (4.7.0).
+- [x] `npm run typecheck`, `npm run test`, `npm run build` all pass.
+- [x] `npm run e2e` passes (15 passed locally + CI `frontend` job green).
+- [x] Dependabot alerts **#1 (esbuild)** and **#3 (vite)** auto-closed on merge to `main` (plus the new ws alert #58qx).
 
 ## Risks
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,65 @@
 
 ---
 
+## Session: 2026-05-31 — Plan 026 complete: admin-ui vite 6 upgrade clears last Dependabot alerts
+
+### Summary
+
+Picked up "address the Dependabot findings". At session start the repo had **2
+open MEDIUM alerts** in `web/admin-ui` (vite GHSA-4w7w-66w2-5vf9, esbuild
+GHSA-67mh-4wv8-2f99) — the HIGH playwright one had already been cleared by PR
+#113. Executed the ready-and-specced **Plan 026** (vite 5 → 6 upgrade) on branch
+`fix/admin-ui-vite6-upgrade`. Merged as **PR #117**; repo now has **0 open
+Dependabot alerts**. Also merged PR #116 (skip-inaccessible-projects) into `main`
+at the top of the session.
+
+### What Was Done
+
+- `web/admin-ui/package.json`: `vite ^5.3.1 → ^6.4.2`, `vitest ^1.6.0 → ^3.2.4`.
+  `@vitejs/plugin-react` deliberately **kept on 4.x** (resolved 4.7.0) — its 4.x
+  peer range covers vite 6; 5.x would force vite 8.
+- `npm install` resolved `vite@6.4.2`, `esbuild@0.25.12` (transitive — clears the
+  esbuild alert for free), `vitest@3.2.4`.
+- **New transitive advisory surfaced** by the upgrade: `ws@8.20.0`
+  (GHSA-58qx-3vcg-4xpx, via `jsdom@24`). Cleared in-range to `ws@8.21.0` with
+  plain `npm audit fix` (the single change; **no `--force`**, per the plan's
+  agent guards). This is the "new vite 6 transitive dep introduces its own
+  advisory" risk the plan anticipated.
+
+### Validation (all in `web/admin-ui`, local + CI green)
+
+- `npm audit` → **0 vulnerabilities**
+- `npm run typecheck` → exit 0
+- `npm run test` → **78 passed** (vitest 3 — no migration breakage, nothing
+  skipped/deleted; the vitest 1→3 jump was clean)
+- `npm run build` → exit 0 (vite 6.4.2)
+- `npm run e2e` → **15 passed** (Playwright chromium; needed `npx playwright
+  install chromium` locally first)
+- CI on PR #117: CI Tests, Documentation Validation, both `frontend` jobs — all pass.
+
+### Status
+
+- **Plan 026 → COMPLETE ✅**, moved to `.ai/plans/completed/`.
+- Dependabot: **0 open alerts** (all of vite/esbuild/ws auto-closed on merge).
+
+### Notes
+
+- Left `.claude/settings.json` (permission allowlist growth from this session's
+  npm/npx commands) **uncommitted** — config noise, not part of the fix.
+- A stray `@` leaked into the first commit's subject line (PowerShell here-string
+  `@'...'@` syntax used in the Bash tool, which doesn't honour it) — amended with
+  a Bash heredoc before pushing. Reminder: in the Bash tool use `-F -` heredocs
+  for multi-line commit messages, not the PS `@'...'@` form.
+
+### Next Session — Pickup Points
+
+1. **Plan 027** (shared env-loader) — renumbered from 026 last session, not yet
+   implemented. Likely next pick-up.
+2. Decide whether to discard or keep the uncommitted `.claude/settings.json`
+   permission additions.
+
+---
+
 ## Session: 2026-05-25 — Session close-out: Plan 025 1c/1d dispatched to Copilot
 
 ### Where things stand


### PR DESCRIPTION
Docs close-out for **Plan 026** (admin-ui vite 6 upgrade, implemented in #117).

- Plan 026 status → **COMPLETE ✅**, acceptance criteria ticked, moved to `.ai/plans/completed/`
- PROGRESS.md session entry for 2026-05-31

Context: #117 cleared all three `web/admin-ui` Dependabot alerts (vite, esbuild, and a new transitive `ws` advisory surfaced by the upgrade). Repo now has **0 open Dependabot alerts**. Docs-only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
