### PR TITLE
docs(plan-027): mark COMPLETE and move to completed/

### DIFF
--- a/.ai/plans/completed/027-shared-env-config-loader.md
+++ b/.ai/plans/completed/027-shared-env-config-loader.md
@@ -4,7 +4,15 @@
 > 027 because PR #114 (merged 2026-05-30) reserved Plan 026 for the admin-ui
 > vite 6 upgrade. Content unchanged.
 
-## Status: IN REVIEW — implemented in PR #121 (2026-05-31)
+## Status: COMPLETE ✅ (PR #121, merged 2026-05-31)
+
+Loader helpers moved to `src/config/env_loader.py` (public names); back-compat
+shim kept in `github.py` for the remaining importers (`__init__.py`, `cache.py`,
+`conftest.py`); `azure_devops.py` rewired off `github`. New `test_env_loader.py`
++ `test_azure_devops_config.py`, and the override-of-stale-environment regression
+test added to **both** config suites (with try/finally env cleanup). CI Tests
+green. **Follow-up:** delete the `github.py` shim once nothing imports the
+underscored helper names — tracked as **issue #123**.
 
 > **Related:** [Plan 028](028-static-type-checking-gate.md) adds a static
 > type-checking (mypy) CI gate. It is the complementary half of this work — 027


### PR DESCRIPTION
Close-out for **Plan 027** (shared env/config loader), implemented in #121 (merged).

- Status → **COMPLETE ✅**, moved to `.ai/plans/completed/`
- Both review fixes confirmed landed in #121 (try/finally env cleanup on the two override regression tests; unused `import re` dropped)
- Shim-deletion follow-up opened as **#123**

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
