### PR TITLE
feat(ci): add mypy type-checking gate + fix 29 type errors (Plan 028)

### DIFF
--- a/.ai/plans/028-static-type-checking-gate.md
+++ b/.ai/plans/028-static-type-checking-gate.md
@@ -1,6 +1,13 @@
 # Plan 028: Static Type-Checking Gate (mypy in CI)
 
-## Status: PROPOSED (not started)
+## Status: IN REVIEW — implemented in PR #126 (2026-05-31)
+
+All 29 baseline errors fixed and the `Type Check` CI gate added. mypy clean (76
+files); full Docker suite 904 passed / 0 failed. Notable: a **real latent bug**
+surfaced in `github/extractor.py` (`self.backoff_seconds` → `self.config.backoff_seconds`,
+would `AttributeError` on the rate-limit path), and the `readme_analyzer.py`
+duplicate methods were resolved by deleting the 3 dead shadowed copies (no runtime
+change). Only the last box (branch-protection) is left — a maintainer action on merge.
 
 ## Motivation
 
@@ -179,20 +186,18 @@ optional to avoid scope-creep; the CI gate is the hard requirement.
 
 ## Acceptance criteria
 
-- [ ] `mypy src/ --ignore-missing-imports` (or bare `mypy` with the new config)
+- [x] `mypy src/ --ignore-missing-imports` (or bare `mypy` with the new config)
       reports **Success: no issues found** — all 29 baseline errors fixed.
-- [ ] Fixes are real; any `# type: ignore` carries an inline one-line reason and
-      is justified (only the version-guarded `tomllib` import is expected to
-      qualify).
-- [ ] The `readme_analyzer.py` duplicate-method bug is resolved by removing the
-      wrong definition, not by annotation — with the decision noted in the PR.
-- [ ] `pyproject.toml` has a `[tool.mypy]` section pinning `files = ["src"]` and
+- [x] Fixes are real; any `# type: ignore` carries an inline one-line reason and
+      is justified (only the version-guarded `tomllib` import qualified).
+- [x] The `readme_analyzer.py` duplicate-method bug is resolved by removing the
+      dead shadowed copies, not by annotation — decision noted in the PR.
+- [x] `pyproject.toml` has a `[tool.mypy]` section pinning `files = ["src"]` and
       `ignore_missing_imports = true`, **without** strict flags.
-- [ ] `.github/workflows/tests.yml` has a `Type Check` job that fails on any
+- [x] `.github/workflows/tests.yml` has a `Type Check` job that fails on any
       mypy error.
-- [ ] `bash scripts/run-tests-docker.sh` still passes (no behavioural
-      regression from the fixes).
-- [ ] `Type Check` added to `main` branch-protection required checks.
+- [x] `bash scripts/run-tests-docker.sh` still passes (904 passed, 0 failed).
+- [ ] `Type Check` added to `main` branch-protection required checks. *(maintainer action on merge)*
 
 ## Risks
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,29 @@ jobs:
         run: |
           bash scripts/validate-documentation.sh docs
 
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install mypy
+        run: |
+          python -m pip install --upgrade pip
+          pip install "$(grep -E '^mypy' requirements.txt)"
+
+      - name: Run mypy
+        run: mypy   # config in pyproject.toml [tool.mypy]: files=["src"], ignore_missing_imports
+
   test:
     name: CI Tests
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[tool.mypy]
+# Static type-checking gate (Plan 028). Default checks only — strict per-module
+# overrides (disallow_untyped_defs / check_untyped_defs) are a deliberate
+# follow-up, not enabled here. Scope is src/ (tests/ revisited later).
+files = ["src"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 # Test discovery patterns
 testpaths = ["tests"]

--- a/src/analyzers/dependency_analyzer.py
+++ b/src/analyzers/dependency_analyzer.py
@@ -158,7 +158,7 @@ class DependencyAnalyzer:
         )
 
         # Enrich dependencies if requested
-        if self.enrich and result.dependencies:
+        if self.enricher is not None and result.dependencies:
             logger.info("Enriching dependencies for %s", repo_id)
             try:
                 result.enriched_dependencies = self.enricher.enrich(result.dependencies)

--- a/src/analyzers/parsers/dot_net_parser.py
+++ b/src/analyzers/parsers/dot_net_parser.py
@@ -131,7 +131,7 @@ class DotNetParser(ManifestParser):
           <package id="..." version="..." targetFramework="..." />
         </packages>
         """
-        dependencies = []
+        dependencies: list[DependencyData] = []
 
         try:
             root = ET.fromstring(content)

--- a/src/analyzers/parsers/java_parser.py
+++ b/src/analyzers/parsers/java_parser.py
@@ -25,7 +25,7 @@ class JavaParser(ManifestParser):
 
     def parse(self, content: str, file_path: str) -> list[DependencyData]:
         """Parse pom.xml content."""
-        dependencies = []
+        dependencies: list[DependencyData] = []
 
         try:
             # Handle namespace in pom.xml
@@ -135,7 +135,7 @@ class JavaParser(ManifestParser):
 
         return None
 
-    def _substitute_properties(self, value: str, properties: dict[str, str]) -> str:
+    def _substitute_properties(self, value: str, properties: dict[str, str]) -> Optional[str]:
         """Substitute Maven property references."""
         pattern = r"\$\{([^}]+)\}"
 

--- a/src/analyzers/parsers/node_js_parser.py
+++ b/src/analyzers/parsers/node_js_parser.py
@@ -21,7 +21,7 @@ class NodeJsParser(ManifestParser):
 
     def parse(self, content: str, file_path: str) -> list[DependencyData]:
         """Parse package.json content."""
-        dependencies = []
+        dependencies: list[DependencyData] = []
 
         try:
             data = json.loads(content)

--- a/src/analyzers/parsers/python_parser.py
+++ b/src/analyzers/parsers/python_parser.py
@@ -131,7 +131,8 @@ class PythonParser(ManifestParser):
         except ImportError:
             # Python < 3.11, try tomli
             try:
-                import tomli as tomllib
+                # tomllib name intentionally reused for the py<3.11 fallback
+                import tomli as tomllib  # type: ignore[no-redef]
             except ImportError:
                 # No TOML parser available, fall back to regex parsing
                 return self._parse_pyproject_toml_regex(content, file_path)

--- a/src/analyzers/parsers/rust_parser.py
+++ b/src/analyzers/parsers/rust_parser.py
@@ -27,7 +27,8 @@ class RustParser(ManifestParser):
             import tomllib
         except ImportError:
             try:
-                import tomli as tomllib
+                # Py<3.11 fallback; tomllib name intentionally reused
+                import tomli as tomllib  # type: ignore[no-redef]
             except ImportError:
                 # Fall back to regex parsing
                 return self._parse_cargo_toml_regex(content, file_path)

--- a/src/analyzers/readme_analyzer.py
+++ b/src/analyzers/readme_analyzer.py
@@ -227,7 +227,7 @@ class ReadmeAnalyzer:
 
     def _detect_technologies(self, content_lower: str, scope_type: Optional[str] = None) -> Dict[str, List[str]]:
         """Detect technologies mentioned in README."""
-        tech_stack = {
+        tech_stack: Dict[str, List[str]] = {
             'languages': [],
             'frameworks': [],
             'databases': [],
@@ -272,39 +272,6 @@ class ReadmeAnalyzer:
                 return True
         return False
 
-    def _calculate_documentation_score(
-        self,
-        sections: Dict[str, bool],
-        tech_stack: Dict[str, List[str]],
-        word_count: int,
-        has_badges: bool,
-        has_toc: bool
-    ) -> float:
-        """Calculate documentation quality score (0-10)."""
-        score = 0.0
-
-        # Section completeness (4 points)
-        section_score = sum(sections.values()) / len(sections) * 4
-        score += section_score
-
-        # Content length (2 points)
-        if word_count >= 200:
-            score += 2
-        elif word_count >= 50:
-            score += 1
-
-        # Technology information (2 points)
-        if tech_stack['all']:
-            score += min(len(tech_stack['all']) * 0.5, 2)
-
-        # Professional touches (2 points)
-        if has_badges:
-            score += 1
-        if has_toc:
-            score += 1
-
-        return min(score, 10.0)
-
     def _calculate_readability_score(self, content: str, word_count: int) -> float:
         """Calculate readability score (0-10) based on structure and clarity."""
         if word_count == 0:
@@ -345,59 +312,6 @@ class ReadmeAnalyzer:
             score -= 1
 
         return max(0.0, min(score, 10.0))
-
-    def _extract_purpose(self, content: str) -> Optional[str]:
-        """Extract project purpose from the first paragraph or description."""
-        lines = content.strip().split('\n')
-
-        # Skip title and empty lines
-        description_start = 0
-        for i, line in enumerate(lines):
-            if line.strip() and not line.startswith('#'):
-                description_start = i
-                break
-
-        # Get first substantial paragraph
-        purpose_lines = []
-        for line in lines[description_start:]:
-            line = line.strip()
-            if not line:
-                if purpose_lines:
-                    break
-                continue
-            if line.startswith('#'):
-                break
-            purpose_lines.append(line)
-            if len(' '.join(purpose_lines)) > 300:  # Limit length
-                break
-
-        purpose = ' '.join(purpose_lines).strip()
-        return purpose if len(purpose) > 10 else None
-
-    def _extract_features(self, content: str) -> List[str]:
-        """Extract key features from README content."""
-        features = []
-
-        # Look for feature lists
-        feature_patterns = [
-            r'(?:^|\n)(?:##?\s*)?(?:features?|highlights?|benefits?).*?(?=\n(?:#|$))',
-            r'(?:^|\n)[\-\*\+]\s*(.+?)(?=\n(?:[\-\*\+]|\n|$))'
-        ]
-
-        for pattern in feature_patterns:
-            matches = re.findall(pattern, content, re.IGNORECASE | re.MULTILINE | re.DOTALL)
-            for match in matches:
-                if isinstance(match, tuple):
-                    match = match[0]
-
-                # Extract list items
-                list_items = re.findall(r'[\-\*\+]\s*(.+)', match)
-                for item in list_items:
-                    item = item.strip()
-                    if 10 <= len(item) <= 100:  # Reasonable feature length
-                        features.append(item)
-
-        return features[:10]  # Limit to 10 features
 
     def _calculate_scope_coverage(
         self,
@@ -521,7 +435,7 @@ class ReadmeAnalyzer:
                 score += weight
 
         # Content length scoring (scope-adjusted)
-        min_words = {
+        min_words: Dict[Optional[str], int] = {
             "repository": 200,
             "module": 100,
             "package": 100,
@@ -558,7 +472,7 @@ class ReadmeAnalyzer:
                 break
 
         # Get first substantial paragraph
-        purpose_lines = []
+        purpose_lines: list[str] = []
         for line in lines[description_start:]:
             line = line.strip()
             if not line:
@@ -570,12 +484,13 @@ class ReadmeAnalyzer:
             purpose_lines.append(line)
 
             # Adjust length based on scope
-            max_length = {
+            max_length_by_scope: Dict[Optional[str], int] = {
                 "repository": 400,
                 "module": 300,
                 "package": 250,
                 "component": 200
-            }.get(scope_type, 300)
+            }
+            max_length = max_length_by_scope.get(scope_type, 300)
 
             if len(' '.join(purpose_lines)) > max_length:
                 break

--- a/src/analyzers/technology_detector.py
+++ b/src/analyzers/technology_detector.py
@@ -6,7 +6,7 @@ by analyzing file extensions, configuration files, and dependencies.
 """
 
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Set
+from typing import Optional, List, Dict, Set, Any
 from datetime import datetime, UTC
 
 
@@ -256,8 +256,8 @@ class TechnologyDetector:
     def detect(
         self,
         file_names: List[str],
-        file_tree: Optional[List[Dict[str, any]]] = None,
-        language_data: Optional[List[Dict[str, any]]] = None,
+        file_tree: Optional[List[Dict[str, Any]]] = None,
+        language_data: Optional[List[Dict[str, Any]]] = None,
     ) -> TechnologyDetection:
         """
         Detect technologies used in a repository.
@@ -326,7 +326,7 @@ class TechnologyDetector:
     def _detect_languages(
         self,
         file_names: List[str],
-        language_data: Optional[List[Dict[str, any]]] = None
+        language_data: Optional[List[Dict[str, Any]]] = None
     ) -> List[str]:
         """Detect programming languages."""
         languages: Set[str] = set()

--- a/src/config/env_loader.py
+++ b/src/config/env_loader.py
@@ -31,8 +31,8 @@ def load_env_file(env_file: str | Path, override: bool = False) -> dict[str, str
     if not os.access(env_path, os.R_OK):
         return {}
 
-    loaded_vars = {}
-    raw_vars = {}
+    loaded_vars: dict[str, str] = {}
+    raw_vars: dict[str, str] = {}
 
     # First pass: load all raw values
     try:

--- a/src/extractors/base.py
+++ b/src/extractors/base.py
@@ -729,6 +729,8 @@ class RepositoryExtractor(ABC):
             return ["/"]
 
         scope_path = readme.scope_path
+        if scope_path is None:
+            return []
         affected_paths = [scope_path]
 
         # Add all subdirectories under the scope path

--- a/src/extractors/github/extractor.py
+++ b/src/extractors/github/extractor.py
@@ -20,7 +20,7 @@ Key API Behavior Note:
 import logging
 import time
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Any
 
 from github import GithubException
 from github.Repository import Repository as GHRepository
@@ -43,6 +43,7 @@ from src.extractors.base import (
     PRReviewData,
     PRCommentData,
     FileTreeItem,
+    LanguageData,
 )
 from src.extractors.cache import cached
 
@@ -337,8 +338,6 @@ class GitHubExtractor(RepositoryExtractor):
         Returns language data with byte counts and percentages.
         GitHub API returns a dict of {language_name: byte_count}.
         """
-        from src.extractors.base import LanguageData
-        
         repo = self._get_repo(repo_id)
         
         try:
@@ -383,7 +382,7 @@ class GitHubExtractor(RepositoryExtractor):
         """Get commits for a repository."""
         repo = self._get_repo(repo_id)
 
-        kwargs = {}
+        kwargs: dict[str, Any] = {}
         if branch:
             kwargs["sha"] = branch
         if since:
@@ -624,8 +623,8 @@ class GitHubExtractor(RepositoryExtractor):
             try:
                 reset_epoch = int(reset_raw)
                 now = int(time.time())
-                wait = max(reset_epoch - now, self.backoff_seconds)
-                return min(wait, self.max_backoff_seconds)
+                wait = max(reset_epoch - now, self.config.backoff_seconds)
+                return min(wait, self.config.max_backoff_seconds)
             except Exception:
                 pass
         return min(self.config.backoff_seconds, self.config.max_backoff_seconds)


### PR DESCRIPTION
Implements **Plan 028**. `mypy>=1.8.0` was already a dependency but **nothing ran it**, so parameter/type/attribute bugs only surfaced at runtime (the motivating incident: a real Azure-token run). This adds a `Type Check` CI job and fixes the 29 errors `mypy src/` reported so the gate starts green.

## CI / config
- `pyproject.toml`: `[tool.mypy]` `files=["src"]`, `ignore_missing_imports=true` — **default checks only** (strict per-module overrides are a deliberate follow-up).
- `.github/workflows/tests.yml`: standalone **`Type Check`** job (no Postgres), runs bare `mypy`.
- On merge: add **`Type Check`** to `main` branch-protection required checks.

## Notable fixes (not just annotations)
- **REAL BUG** — `github/extractor.py` used `self.backoff_seconds` / `self.max_backoff_seconds`, which don't exist on `GitHubExtractor` (they live on `self.config`, as the next line already uses). Would `AttributeError` on the rate-limit-reset path. → `self.config.*`.
- **`readme_analyzer.py` duplicate methods** — `_calculate_documentation_score` / `_extract_purpose` / `_extract_features` were each defined **twice**. Python keeps the 2nd (scope-aware) definition, so the earlier copies were **dead code**; the live versions and call sites are unchanged. Deleted the 3 dead copies → **no runtime change** (this is the `-97`-line file).
- `base.py`: guard `None` `scope_path` (also prevents a latent `None + str` crash).
- `java_parser._substitute_properties`: return type → `Optional[str]` (it returns `None` on unresolved props; caller's `_create_dependency` already accepts `Optional`).
- `dependency_analyzer`: narrow `self.enrich` → `self.enricher is not None`.
- `github/extractor.py`: hoist `LanguageData` import for the return annotation; annotate `kwargs: dict[str, Any]`.

## Mechanical
Missing collection annotations; `any` → `Any` in `technology_detector`; `list[DependencyData]` in 3 parsers. **Only suppression**: `# type: ignore[no-redef]` on the two `tomllib` py<3.11 fallback imports, each with an inline reason (the one legitimate case the plan anticipated).

## Verification
- `mypy` clean — **Success: no issues found in 76 source files**.
- Full Docker suite — **904 passed, 3 skipped, 0 failed** (behavioural safety net for the non-trivial fixes).

Plan 028 status flipped to IN REVIEW with acceptance boxes ticked in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
