### PR TITLE
docs(plan-028): mark COMPLETE + log session

### DIFF
--- a/.ai/plans/completed/028-static-type-checking-gate.md
+++ b/.ai/plans/completed/028-static-type-checking-gate.md
@@ -1,13 +1,15 @@
 # Plan 028: Static Type-Checking Gate (mypy in CI)
 
-## Status: IN REVIEW — implemented in PR #126 (2026-05-31)
+## Status: COMPLETE ✅ (PR #126, merged 2026-05-31)
 
 All 29 baseline errors fixed and the `Type Check` CI gate added. mypy clean (76
-files); full Docker suite 904 passed / 0 failed. Notable: a **real latent bug**
-surfaced in `github/extractor.py` (`self.backoff_seconds` → `self.config.backoff_seconds`,
-would `AttributeError` on the rate-limit path), and the `readme_analyzer.py`
-duplicate methods were resolved by deleting the 3 dead shadowed copies (no runtime
-change). Only the last box (branch-protection) is left — a maintainer action on merge.
+files); full Docker suite 904 passed / 0 failed. **`Type Check` is now a required
+status check on `main`** (alongside `CI Tests` and `Documentation Validation`,
+strict mode). Notable: a **real latent bug** surfaced in `github/extractor.py`
+(`self.backoff_seconds` → `self.config.backoff_seconds`, would `AttributeError`
+on the rate-limit path), and the `readme_analyzer.py` duplicate methods were
+resolved by deleting the 3 dead shadowed copies (no runtime change). Verified
+still green on `main` after PR #125 (Plan 027 shim removal) merged alongside.
 
 ## Motivation
 
@@ -197,7 +199,7 @@ optional to avoid scope-creep; the CI gate is the hard requirement.
 - [x] `.github/workflows/tests.yml` has a `Type Check` job that fails on any
       mypy error.
 - [x] `bash scripts/run-tests-docker.sh` still passes (904 passed, 0 failed).
-- [ ] `Type Check` added to `main` branch-protection required checks. *(maintainer action on merge)*
+- [x] `Type Check` added to `main` branch-protection required checks (2026-05-31).
 
 ## Risks
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,85 @@
 
 ---
 
+## Session: 2026-05-31 (evening) — Plan 028 implemented + merged; Plan 027 shim removed; type-check gate live on main
+
+### Summary
+
+Implemented **Plan 028** (static type-checking gate) directly with Claude — the
+agreed call over Copilot, because the gate (mypy) is gameable by suppression and
+the `readme_analyzer.py` duplicate-method case needed real investigation. Merged
+as **PR #126**. In parallel, Copilot completed the **Plan 027 shim-removal**
+follow-up (issue #123) as **PR #125**, also merged. `Type Check` is now a
+**required status check on `main`**.
+
+### Plan 028 — what shipped (PR #126)
+
+- Fixed all **29** `mypy src/` errors (default mode, `--ignore-missing-imports`).
+- `pyproject.toml`: `[tool.mypy]` `files=["src"]`, `ignore_missing_imports=true`
+  (default checks only — strict per-module is a logged follow-up).
+- `tests.yml`: standalone **`Type Check`** job (no Postgres, ~15s).
+- **Real latent bug found by mypy**: `github/extractor.py` used
+  `self.backoff_seconds` / `self.max_backoff_seconds` — attrs that live on
+  `self.config`, not `self` (the next line already used `self.config.*`). Would
+  `AttributeError` on the rate-limit-reset path. Fixed.
+- **`readme_analyzer.py` duplicate methods**: `_calculate_documentation_score` /
+  `_extract_purpose` / `_extract_features` were each defined twice. Python keeps
+  the 2nd (scope-aware) def, so the earlier copies were dead code — deleted the 3
+  shadowed copies, **no runtime change** (file is `-97` lines net). Call sites and
+  live versions unchanged.
+- Other judgment fixes: `base.py` None-guard (also prevents a latent `None + str`
+  crash); `java_parser._substitute_properties` → `Optional[str]` (caller already
+  accepts it); `dependency_analyzer` narrowed `self.enrich` → `self.enricher is
+  not None`; `LanguageData` forward-ref import hoisted; `kwargs: dict[str, Any]`.
+- Only suppression: `# type: ignore[no-redef]` on the two `tomllib` py<3.11
+  fallback imports, each with an inline reason (the one case the plan anticipated).
+- Verified: `mypy` clean (76 files); full Docker suite **904 passed / 0 failed**.
+
+### Plan 027 follow-up — shim removed (PR #125, Copilot)
+
+- Issue #123 done: `github.py` env-loader re-export shim deleted; `__init__.py`,
+  `cache.py`, `conftest.py` repointed to `src.config.env_loader` public names.
+  **Zero** underscored-helper references remain anywhere. Reviewed clean.
+
+### Branch protection
+
+- Added **`Type Check`** to `main` required checks via `gh api` (strict mode
+  preserved; now: CI Tests, Documentation Validation, Type Check). Verified mypy
+  green on the combined `main` after both PRs merged.
+
+### Decision captured (memory)
+
+- For a static-analysis gate where the metric is gameable + there's a real
+  judgment call, **Claude implements directly rather than dispatching Copilot** —
+  worked well here (Copilot would likely have suppressed or mis-resolved the
+  duplicate-method bug). Fleet-of-agents was considered and rejected: too small,
+  cohesive, single-PR, with a global verification gate.
+
+### Status
+
+- **Plan 028 → COMPLETE**, moved to `.ai/plans/completed/`.
+- **Plan 027 → COMPLETE** (shim follow-up #123 also done).
+- Type-safety reflection: discussed whether mypy-on-Python is an anti-pattern /
+  whether to switch languages — conclusion: no. Default-mode mypy on an I/O-bound
+  analyzer is sound; the watch-out is over-rotating into maximal strictness.
+
+### Next Session — Pickup Points
+
+1. **Optional Plan 028 follow-ups** (logged in the plan): ratchet
+   `src/extractors/` + `src/config/` to per-module strict mypy once the baseline
+   holds; wire `flake8`/`pylint` (both already in `requirements.txt`); extend
+   type-checking to `tests/`.
+2. **`.claude/settings.json`** — still has uncommitted permission-allowlist
+   additions from this session. Keep or discard.
+
+### Branch / state at close
+
+- On `docs/plan-028-complete` writing this. `main` synced; PRs #117/#118/#119/
+  #120/#121/#122/#124/#125/#126 all merged this day. No open PRs. Type Check
+  required on `main`.
+
+---
+
 ## Session: 2026-05-31 (later) — Dependabot cleared, Plan 028 created, Plan 027 dispatched to Copilot
 
 ### Summary


### PR DESCRIPTION
Close-out for **Plan 028** (mypy type-checking gate), implemented in #126 (merged).

- Plan 028 status → **COMPLETE ✅**, moved to `.ai/plans/completed/`, last acceptance box ticked (`Type Check` now a required check on `main`).
- PROGRESS.md session entry covering: Plan 028 impl (#126), Plan 027 shim-removal (#125, Copilot/issue #123), branch-protection update, and the type-safety discussion.

State: `Type Check` is required on `main` (strict mode); mypy verified green on the combined `main` after both PRs. No open PRs besides this docs one.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
