### PR TITLE
docs(prompts): add model self-check preamble for Copilot agents

### DIFF
--- a/.ai/prompts/README.md
+++ b/.ai/prompts/README.md
@@ -50,3 +50,21 @@ both route sets). Merge order doesn't matter.
 ## Why this folder exists
 
 Previous Copilot agent rounds on this project have ended with the agent declaring done while CI was red, costing 2+ feedback rounds per task. Every prompt here includes a non-negotiable acceptance block requiring `gh pr checks --watch` and root-cause fixing on red. Reuse the block when drafting new prompts.
+
+## Reusable block: model self-check preamble
+
+Paste this as the **first section** of every new agent prompt. The convention is to back the Copilot agent with **Claude Sonnet 4.6** (Opus 4.6 for hard tasks); this block surfaces a mis-dispatch *before* any work happens.
+
+> **Caveat (read before relying on this):** the agent **cannot change its own model** — that is fixed by the model picker at dispatch time — and a model's self-reported identity is **not reliable** (models often misstate or don't know which model they are). So this is a best-effort *declare-and-halt* signal, not a guarantee. The real guard is the human picking the right model in the Copilot UI before dispatch.
+
+```md
+## STEP 0 — Model self-check (do this FIRST, before anything else)
+
+This task is intended to run on **Claude Sonnet 4.6** (or **Claude Opus 4.6** for harder work). Before doing any other step:
+
+1. State, as the first line of your first response and in your opening PR/issue comment: **"Running as: <model name/version>"**.
+2. If you are confident you are NOT one of the expected models (Claude Sonnet 4.6 / Claude Opus 4.6) — e.g. you are a GPT or Gemini model — **STOP immediately. Do not write code, do not open a PR.** Post a comment: *"⚠️ Model mismatch: dispatched on <model>, but this task expects Claude Sonnet 4.6 / Opus 4.6. Please re-dispatch with the correct model selected in the Copilot model picker."* Then halt.
+3. If you cannot reliably determine which model you are, say so explicitly ("Cannot confirm model identity") and **proceed with caution**, flagging it in the PR body so the human can verify the picker.
+
+You cannot switch your own model — only the human can, via the model picker at dispatch. Do not attempt to.
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,8 @@
       "Bash(git show *)",
       "Read(//tmp/**)",
       "Bash(bash scripts/run-tests-docker.sh *)",
-      "Bash(git add *)"
+      "Bash(git add *)",
+      "Bash(gh issue *)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Adds a reusable **"STEP 0 — Model self-check"** block to [`.ai/prompts/README.md`](.ai/prompts/README.md) so every future Copilot agent prompt makes the agent:

- declare `"Running as: <model>"` up front (first line + opening PR/issue comment), and
- **halt before writing any code** if it is confident it is a non-Claude model (GPT/Gemini), posting a ⚠️ mismatch warning so the task can be re-dispatched.

Convention captured: back the Copilot SWE agent with **Claude Sonnet 4.6** (Opus 4.6 for hard tasks).

### Honest limitation (kept front-and-centre in the doc)

This is **best-effort**, not a guarantee:
- the agent **cannot switch its own model** — that is fixed by the model picker at dispatch time, and
- a model's **self-reported identity is unreliable** — models often misstate or don't know which model they are.

The real guard remains the human selecting the correct model in the Copilot picker before dispatch.

## Also included

- Allowlists `gh issue *` in `.claude/settings.json` (local permission tweak).

## Scope

Docs/config only — no code, no behaviour change. The already-merged wave prompts are left untouched as historical reference; the block applies to prompts drafted from now on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
