### PR TITLE
feat(plan-028): flake8 + pylint lint gates and strict mypy for extractors/config

### DIFF
--- a/.ai/plans/completed/028-static-type-checking-gate.md
+++ b/.ai/plans/completed/028-static-type-checking-gate.md
@@ -220,8 +220,16 @@ optional to avoid scope-creep; the CI gate is the hard requirement.
 
 ## Follow-ups (out of scope, capture as issues)
 
-- Ratchet `src/extractors/` and `src/config/` to per-module strict mypy
-  (`disallow_untyped_defs`, `check_untyped_defs`) once the baseline holds.
-- Wire `flake8` and/or `pylint` (both already in `requirements.txt`) as
-  additional non-blocking-then-required gates.
+- ✅ **DONE (2026-06-06)** — Ratchet `src/extractors/` and `src/config/` to
+  per-module strict mypy (`disallow_untyped_defs`, `check_untyped_defs`). Added
+  as a `[[tool.mypy.overrides]]` block in `pyproject.toml`; fixed 27 findings
+  (22 missing annotations + a real `raise None` fall-through in
+  `azure_devops/extractor._api_call_with_retry` and `asdict`/instance-vs-class
+  guards in `extractors/cache.py`).
+- ✅ **DONE (2026-06-06)** — Wire `flake8` and `pylint` as gates. New `Lint` job
+  in `tests.yml`: `flake8 src/` (config in `.flake8`: `select = F,E9` — pyflakes
+  bug checks + syntax errors; fixed 27 F-code findings) and
+  `pylint src/ --errors-only --disable=E0401` (already clean). Full PEP8/style
+  (E/W line-length + whitespace, ~288 findings) deliberately deferred to a
+  separate `black` pass — see `.flake8` for the ratchet note.
 - Extend type-checking to `tests/`.

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,21 @@
+# flake8 gate (Plan 028 follow-up). Baseline-first, mirroring the mypy gate:
+# we enforce the high-value *bug* checks now and defer full PEP8 style to a
+# separate `black`/autoformat pass (E/W line-length + whitespace are ~288
+# findings and pure churn — not regressions).
+#
+#   F   = pyflakes: unused imports/vars, undefined names, f-strings without
+#         placeholders, duplicate args, etc. (real bugs)
+#   E9  = runtime/syntax errors (E901/E902/E999) and tokenisation failures
+#
+# To ratchet toward full style later, drop `select` and tune `max-line-length`
+# + `extend-ignore` after running black across src/.
+[flake8]
+select = F,E9
+exclude =
+    .git,
+    __pycache__,
+    .venv,
+    venv,
+    build,
+    dist,
+    migrations

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,35 @@ jobs:
       - name: Run mypy
         run: mypy   # config in pyproject.toml [tool.mypy]: files=["src"], ignore_missing_imports
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install linters
+        run: |
+          python -m pip install --upgrade pip
+          pip install "$(grep -E '^flake8' requirements.txt)" "$(grep -E '^pylint' requirements.txt)"
+
+      - name: Run flake8
+        run: flake8 src/   # config in .flake8: select = F,E9 (real bugs; style deferred to a black pass)
+
+      - name: Run pylint (errors only)
+        # --errors-only catches genuine errors without the noisy convention/refactor
+        # categories; E0401 (import-error) is disabled because third-party deps are
+        # not installed in the lint env, mirroring mypy's ignore_missing_imports.
+        run: pylint src/ --errors-only --disable=E0401
+
   test:
     name: CI Tests
     runs-on: ubuntu-latest

--- a/docs/01-strategy/requirements.md
+++ b/docs/01-strategy/requirements.md
@@ -324,7 +324,7 @@ The Repository Analysis System is a platform designed to provide comprehensive i
 
 | ID      | Requirement            | Target                                              | Status | Notes                                                    |
 | ------- | ---------------------- | --------------------------------------------------- | ------ | -------------------------------------------------------- |
-| NFR-5.1 | Code quality standards | Enforced via pre-commit hooks (black, flake8, mypy) | 🔶     | **mypy** is now a required CI gate (`Type Check` job, config in `pyproject.toml`) — Plan 028 (PR #126); black/flake8 and pre-commit hooks not yet configured |
+| NFR-5.1 | Code quality standards | Enforced via pre-commit hooks (black, flake8, mypy) | 🔶     | CI gates live: **mypy** (`Type Check`, Plan 028/PR #126; strict for extractors+config), **flake8** (`Lint`, `select=F,E9` bug checks) and **pylint** (`--errors-only`) — Plan 028 follow-up. Still pending: **black** autoformat (full PEP8 style) and pre-commit hooks |
 | NFR-5.2 | Test coverage          | Minimum 80% coverage for core modules               | 🔶     | Unit, contract, and integration tests exist; % not measured |
 | NFR-5.3 | Documentation          | All modules documented with docstrings              | 🔶     | Some docstrings present; coverage incomplete             |
 | NFR-5.4 | Logging                | Structured logging with correlation IDs             | ✅     | Structlog configured                                     |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,17 @@
 [tool.mypy]
-# Static type-checking gate (Plan 028). Default checks only — strict per-module
-# overrides (disallow_untyped_defs / check_untyped_defs) are a deliberate
-# follow-up, not enabled here. Scope is src/ (tests/ revisited later).
+# Static type-checking gate (Plan 028). Default checks across all of src/.
+# Per-module strict ratchet for src/extractors + src/config lives in the
+# overrides below (Plan 028 follow-up). tests/ revisited later.
 files = ["src"]
 ignore_missing_imports = true
+
+# Strict ratchet: fully-typed signatures required in the extractor + config
+# layers (the platform boundary, where type bugs are most costly). Extend this
+# list module-by-module as each package is brought up to strict.
+[[tool.mypy.overrides]]
+module = ["src.extractors.*", "src.config.*"]
+disallow_untyped_defs = true
+check_untyped_defs = true
 
 [tool.pytest.ini_options]
 # Test discovery patterns

--- a/src/analyzers/contributor_analyzer.py
+++ b/src/analyzers/contributor_analyzer.py
@@ -7,7 +7,7 @@ pull request activity, active days, and commit message quality.
 
 import re
 from dataclasses import dataclass
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, UTC
 from decimal import Decimal
 from typing import Optional
 
@@ -15,7 +15,6 @@ from sqlalchemy import func, distinct, case
 from sqlalchemy.orm import Session
 
 from src.database.models import (
-    Contributor,
     ContributorMetric,
     Commit,
     PullRequest,

--- a/src/analyzers/dependency_enricher.py
+++ b/src/analyzers/dependency_enricher.py
@@ -9,7 +9,7 @@ Enriches extracted dependencies with additional information from external APIs:
 
 import logging
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date
 from typing import Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -61,7 +61,7 @@ def _version_is_affected(current: Optional[str], fixed_in: Optional[str]) -> boo
     if not current or not fixed_in:
         return False
     try:
-        from packaging.version import Version, InvalidVersion
+        from packaging.version import Version
         return Version(current) < Version(fixed_in)
     except Exception:
         return False

--- a/src/analyzers/osv_client.py
+++ b/src/analyzers/osv_client.py
@@ -12,10 +12,7 @@ API Docs: https://api.osv.dev/v1/query
 
 import logging
 from typing import Optional
-from datetime import datetime, UTC
 import httpx
-
-from src.extractors.base import DependencyData
 
 logger = logging.getLogger(__name__)
 

--- a/src/analyzers/readme_analyzer.py
+++ b/src/analyzers/readme_analyzer.py
@@ -7,7 +7,7 @@ including technology stack, purpose, installation instructions, and documentatio
 
 import re
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict
 from datetime import datetime
 
 

--- a/src/api/rescan.py
+++ b/src/api/rescan.py
@@ -21,7 +21,7 @@ from src.scheduler.celery_app import celery_app
 from src.database import get_session
 from src.database.models.repository import Repository
 from src.database.models.package import Package
-from src.database.models.dependency import RepositoryDependency, Vulnerability
+from src.database.models.dependency import RepositoryDependency
 from src.database.models.service import RepositoryService, Service
 from src.database.models.radar import RadarBlip as RadarBlipModel, RadarBlipHistory, RadarPublication
 
@@ -758,7 +758,8 @@ def export_radar():
                 # Validate date
                 try:
                     from datetime import datetime as _dt
-                    target_date = _dt.strptime(date_str, "%Y-%m-%d").date()
+                    # Parse to validate the format; raises ValueError if invalid.
+                    _dt.strptime(date_str, "%Y-%m-%d")
                 except ValueError:
                     return jsonify({"status": "error", "message": f"Invalid date format: {date_str}"}), 404
 

--- a/src/database/models/organization.py
+++ b/src/database/models/organization.py
@@ -2,7 +2,6 @@
 Organization and Project models.
 """
 
-from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import ForeignKey, String, Text, UniqueConstraint

--- a/src/database/models/team_metric.py
+++ b/src/database/models/team_metric.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, String
+from sqlalchemy import DateTime, ForeignKey, Integer, Numeric
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database.models.base import Base

--- a/src/database/storage.py
+++ b/src/database/storage.py
@@ -359,7 +359,7 @@ def get_or_create_service(
     if not service:
         service = Service(
             name=service_name,
-            purpose=purpose or f"Auto-created from repository.json",
+            purpose=purpose or "Auto-created from repository.json",
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
         )

--- a/src/database/team_analytics.py
+++ b/src/database/team_analytics.py
@@ -11,9 +11,8 @@ The legacy contributors.team_id field should NOT be used for new code.
 See docs/04-implementation/contributor-team-migration.md for details.
 """
 
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, UTC
 from typing import Optional
-from decimal import Decimal
 
 from sqlalchemy import func, and_, or_
 from sqlalchemy.orm import Session

--- a/src/extractors/azure_devops/client.py
+++ b/src/extractors/azure_devops/client.py
@@ -2,9 +2,8 @@
 Azure DevOps API client configuration and authentication.
 """
 
-import os
 from functools import lru_cache
-from typing import Optional
+from typing import Any, Optional
 
 from azure.devops.connection import Connection
 from msrest.authentication import BasicAuthentication
@@ -45,13 +44,13 @@ def get_connection(config: Optional[AzureDevOpsExtractorConfig] = None) -> Conne
     return Connection(base_url=org_url, creds=credentials)
 
 
-def get_git_client(config: Optional[AzureDevOpsExtractorConfig] = None):
+def get_git_client(config: Optional[AzureDevOpsExtractorConfig] = None) -> Any:
     """Get the Git client for repository operations."""
     connection = get_connection(config)
     return connection.clients.get_git_client()
 
 
-def get_core_client(config: Optional[AzureDevOpsExtractorConfig] = None):
+def get_core_client(config: Optional[AzureDevOpsExtractorConfig] = None) -> Any:
     """Get the Core client for project operations."""
     connection = get_connection(config)
     return connection.clients.get_core_client()

--- a/src/extractors/azure_devops/extractor.py
+++ b/src/extractors/azure_devops/extractor.py
@@ -16,7 +16,7 @@ import logging
 import os
 import time
 from datetime import datetime
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from azure.devops.exceptions import AzureDevOpsServiceError
 from azure.devops.v7_1.git.models import (
@@ -56,13 +56,13 @@ class AzureDevOpsExtractor(RepositoryExtractor):
         self._logger = logging.getLogger(__name__)
 
     @property
-    def git_client(self):
+    def git_client(self) -> Any:
         if self._git_client is None:
             self._git_client = get_git_client(self.config)
         return self._git_client
 
     @property
-    def core_client(self):
+    def core_client(self) -> Any:
         if self._core_client is None:
             self._core_client = get_core_client(self.config)
         return self._core_client
@@ -73,7 +73,9 @@ class AzureDevOpsExtractor(RepositoryExtractor):
 
     # ── Rate Limiting ─────────────────────────────────────────────────
 
-    def _api_call_with_retry(self, api_callable, *args, **kwargs):
+    def _api_call_with_retry(
+        self, api_callable: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Any:
         """
         Execute an Azure DevOps API call with retry and exponential backoff.
 
@@ -97,7 +99,9 @@ class AzureDevOpsExtractor(RepositoryExtractor):
                     time.sleep(sleep_time)
                 else:
                     raise
-        raise last_exception
+        if last_exception is not None:
+            raise last_exception
+        raise RuntimeError("Retry loop exited without a result or exception")
 
     @staticmethod
     def _is_throttled(exc: AzureDevOpsServiceError) -> bool:
@@ -169,7 +173,7 @@ class AzureDevOpsExtractor(RepositoryExtractor):
         except Exception as e:
             raise ValueError(f"Repository {repo_id} not found: {e}")
 
-    def _build_repository_data(self, repo, organization: str) -> RepositoryData:
+    def _build_repository_data(self, repo: Any, organization: str) -> RepositoryData:
         """Build RepositoryData from an Azure DevOps GitRepository object."""
         return RepositoryData(
             repo_id=str(repo.id),
@@ -195,7 +199,7 @@ class AzureDevOpsExtractor(RepositoryExtractor):
         )
 
     @staticmethod
-    def _infer_visibility(repo) -> Optional[bool]:
+    def _infer_visibility(repo: Any) -> Optional[bool]:
         """
         Infer repository privacy from project visibility.
 

--- a/src/extractors/base.py
+++ b/src/extractors/base.py
@@ -215,7 +215,7 @@ class RepositoryExtractor(ABC):
     to provide a consistent API for data extraction.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._cache: dict = {}
         self._cache_hits: int = 0
         self._cache_misses: int = 0

--- a/src/extractors/cache.py
+++ b/src/extractors/cache.py
@@ -16,6 +16,7 @@ from dataclasses import asdict, is_dataclass
 from datetime import datetime
 from importlib import import_module
 from pathlib import Path
+from typing import Any, Callable
 
 from src.config.env_loader import find_project_root
 
@@ -32,7 +33,7 @@ _FILE_CACHE_DATETIME_KEY = "__cache_datetime__"
 _FILE_CACHE_TUPLE_KEY = "__cache_tuple__"
 
 
-def _normalize_arg(arg):
+def _normalize_arg(arg: object) -> str:
     """Convert an argument to a stable, hashable string for cache keys.
 
     - datetime  → ISO-8601 string  (avoids object identity issues)
@@ -46,7 +47,9 @@ def _normalize_arg(arg):
     return str(arg)
 
 
-def _make_cache_key(method_name, args, kwargs):
+def _make_cache_key(
+    method_name: str, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> str:
     """Build a deterministic string key from method name + call arguments.
 
     ``args`` should already exclude ``self`` (the decorator handles that).
@@ -86,10 +89,10 @@ def _file_cache_path(method_name: str, cache_key: str) -> Path:
     return _file_cache_dir(method_name) / f"{cache_hash}.json"
 
 
-def _encode_cache_value(value):
+def _encode_cache_value(value: Any) -> Any:
     if isinstance(value, datetime):
         return {_FILE_CACHE_DATETIME_KEY: value.isoformat()}
-    if is_dataclass(value):
+    if is_dataclass(value) and not isinstance(value, type):
         return {
             _FILE_CACHE_TYPE_KEY: f"{value.__class__.__module__}.{value.__class__.__qualname__}",
             _FILE_CACHE_DATA_KEY: _encode_cache_value(asdict(value)),
@@ -103,7 +106,7 @@ def _encode_cache_value(value):
     return value
 
 
-def _resolve_type(type_path: str):
+def _resolve_type(type_path: str) -> Any:
     module_name, _, qualname = type_path.rpartition(".")
     module = import_module(module_name)
     attr = module
@@ -112,7 +115,7 @@ def _resolve_type(type_path: str):
     return attr
 
 
-def _decode_cache_value(value):
+def _decode_cache_value(value: Any) -> Any:
     if isinstance(value, dict):
         if _FILE_CACHE_DATETIME_KEY in value:
             return datetime.fromisoformat(value[_FILE_CACHE_DATETIME_KEY])
@@ -121,7 +124,7 @@ def _decode_cache_value(value):
         if _FILE_CACHE_TYPE_KEY in value and _FILE_CACHE_DATA_KEY in value:
             target_type = _resolve_type(value[_FILE_CACHE_TYPE_KEY])
             data = _decode_cache_value(value[_FILE_CACHE_DATA_KEY])
-            if is_dataclass(target_type):
+            if is_dataclass(target_type) and isinstance(target_type, type):
                 return target_type(**data)
             return data
         return {key: _decode_cache_value(item) for key, item in value.items()}
@@ -130,7 +133,7 @@ def _decode_cache_value(value):
     return value
 
 
-def _read_file_cache(path: Path):
+def _read_file_cache(path: Path) -> Any:
     try:
         payload = path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -147,7 +150,7 @@ def _read_file_cache(path: Path):
     return _decode_cache_value(data)
 
 
-def _write_file_cache(path: Path, value) -> bool:
+def _write_file_cache(path: Path, value: Any) -> bool:
     try:
         payload = json.dumps(_encode_cache_value(value), ensure_ascii=True, separators=(",", ":"))
     except (TypeError, ValueError) as exc:
@@ -181,7 +184,7 @@ def _write_file_cache(path: Path, value) -> bool:
                 pass
 
 
-def cached(method):
+def cached(method: Callable) -> Callable:
     """Decorator that caches the return value of an extractor instance method.
 
     Requirements on the instance (``self``):
@@ -193,7 +196,7 @@ def cached(method):
     """
 
     @functools.wraps(method)
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         key = _make_cache_key(method.__name__, args, kwargs)
 
         method_name = method.__name__

--- a/src/extractors/github/client.py
+++ b/src/extractors/github/client.py
@@ -3,7 +3,6 @@ GitHub API client configuration and authentication.
 """
 
 import os
-from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 

--- a/src/extractors/github/extractor.py
+++ b/src/extractors/github/extractor.py
@@ -25,11 +25,7 @@ from typing import Optional, Any
 from github import GithubException
 from github.Repository import Repository as GHRepository
 
-from src.extractors.github.client import (
-    get_github_client,
-    get_organization_name,
-    get_user_name,
-)
+from src.extractors.github.client import get_github_client
 from src.config.github import GitHubExtractorConfig
 from src.extractors.base import (
     Platform,
@@ -57,14 +53,14 @@ class GitHubExtractor(RepositoryExtractor):
     ):
         super().__init__()
         self.config = config or GitHubExtractorConfig.from_env()
-        self._client = None
+        self._client: Any = None
         self._org_name = self.config.organization
         self._user_name = self.config.user
         self._user_email_cache: dict[str, str] = {}
         self._logger = logging.getLogger(__name__)
 
     @property
-    def client(self):
+    def client(self) -> Any:
         if self._client is None:
             self._client = get_github_client(config=self.config)
             # Ensure paginated calls use the configured page size
@@ -498,7 +494,7 @@ class GitHubExtractor(RepositoryExtractor):
 
         return result
 
-    def _get_pr_reviews(self, pr) -> list[PRReviewData]:
+    def _get_pr_reviews(self, pr: Any) -> list[PRReviewData]:
         """Get reviews for a pull request."""
         reviews = []
 
@@ -526,7 +522,7 @@ class GitHubExtractor(RepositoryExtractor):
 
         return reviews
 
-    def _get_pr_comments(self, pr) -> list[PRCommentData]:
+    def _get_pr_comments(self, pr: Any) -> list[PRCommentData]:
         """Get comments for a pull request."""
         comments = []
 
@@ -580,7 +576,9 @@ class GitHubExtractor(RepositoryExtractor):
 
         return comments
 
-    def _safe_paginated_list(self, paginated, limit: Optional[int] = None):
+    def _safe_paginated_list(
+        self, paginated: Any, limit: Optional[int] = None
+    ) -> list[Any]:
         """Iterate a PyGithub PaginatedList with basic rate-limit backoff and bounds."""
         items = []
         max_items = limit or self.config.max_items_per_list

--- a/src/scheduler/tasks.py
+++ b/src/scheduler/tasks.py
@@ -222,7 +222,7 @@ def compute_service_metrics_task(
                     "unique_contributors": metric.unique_contributors,
                 }
                 
-                logger.info(f"✓ Persisted service metric to database")
+                logger.info("✓ Persisted service metric to database")
                 return {"status": "success", "summary": summary}
         finally:
             session.close()

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -20,7 +20,6 @@ Design notes
 from __future__ import annotations
 
 import logging
-from dataclasses import asdict
 
 from src.utils.extraction_health import HealthReport
 

--- a/src/workflows/azure_devops_analysis.py
+++ b/src/workflows/azure_devops_analysis.py
@@ -147,7 +147,7 @@ class AzureDevOpsAnalysisWorkflow:
                 .first()
             )
 
-            project = store_project(session, org, project_data.name, project_data.description)
+            store_project(session, org, project_data.name, project_data.description)
             logger.info("      Stored project: %s", project_data.name)
 
         self._process_repositories(org_data, project_data.name)
@@ -287,7 +287,7 @@ class AzureDevOpsAnalysisWorkflow:
                     .first()
                 )
 
-                repo = store_repository(session, project, repo_data)
+                store_repository(session, project, repo_data)
                 logger.info("          Stored repository: %s", repo_data.name)
 
             with session_scope() as session:

--- a/src/workflows/github_analysis.py
+++ b/src/workflows/github_analysis.py
@@ -24,7 +24,6 @@ from src.database.storage import (
     store_pull_request,
     store_readme,
     store_dependencies,
-    store_enriched_dependencies,
     store_package_metadata,
     store_repo_dependencies,
     store_languages,
@@ -126,7 +125,7 @@ class GitHubAnalysisWorkflow:
             else:
                 logger.info("  Organization exists: %s", org_data.name)
 
-            project = store_project(
+            store_project(
                 session,
                 org,
                 org_data.name,
@@ -267,7 +266,7 @@ class GitHubAnalysisWorkflow:
                     .first()
                 )
 
-                repo = store_repository(session, project, repo_data)
+                store_repository(session, project, repo_data)
                 logger.info("      Stored repository: %s", repo_data.name)
 
             with session_scope() as session:

--- a/src/workflows/radar_publication.py
+++ b/src/workflows/radar_publication.py
@@ -17,7 +17,6 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.analyzers.radar_categorization import RadarBlip, RadarCategorizer
-from src.database.models.dependency import RepositoryDependency
 from src.database.models.package import Package
 from src.database.models.radar import (
     RadarBlip as RadarBlipModel,


### PR DESCRIPTION
## What

Completes the two **Plan 028** quality-gate follow-ups: wire **flake8 + pylint** into CI, and ratchet **src/extractors + src/config** to **strict mypy**.

## flake8 — bug gate (new `.flake8`: `select = F,E9`)

Baseline-first, mirroring the mypy gate. We enforce the high-value **bug** checks now and defer full PEP8 style to a separate `black` pass (E/W line-length + whitespace = ~288 findings of pure churn, not regressions — noted in `.flake8`).

- Gates on pyflakes `F` (unused imports/vars, undefined names, empty f-strings, …) + `E9` syntax/runtime errors.
- Fixed the **27 F-code findings** across analyzers / api / database / extractors / scheduler / utils / workflows.
- F841 cases (unused locals binding `store_project` / `store_repository`) keep the side-effecting call and drop only the unused binding.

## strict mypy — `src/extractors.*` + `src/config.*` (`pyproject [[tool.mypy.overrides]]`)

`disallow_untyped_defs` + `check_untyped_defs` on the platform boundary, where type bugs are most costly. Config was already strict-clean (0 findings); fixed **27** in extractors:

- 22 missing annotations.
- **Real latent bug**: `azure_devops/extractor._api_call_with_retry` could `raise None` if the retry loop ever fell through — now guarded (raises the captured exception, else a `RuntimeError`). Same class of bug Plan 028 itself caught.
- `extractors/cache.py`: narrowed `is_dataclass(...)` to distinguish instance-vs-class, making `asdict(value)` (encode) and `target_type(**data)` (decode) both correct and type-safe.

## CI

New **`Lint`** job in `tests.yml`: `flake8 src/` and `pylint src/ --errors-only --disable=E0401` (pylint errors were already clean; `E0401` disabled to mirror mypy's `ignore_missing_imports`).

## Verification (Docker)

- `mypy` clean (76 files) · `flake8` 0 · `pylint` 0 errors
- Full CI-equivalent suite via `run-tests-docker.sh`: **906 passed, 3 skipped**

## Docs

Ticked the two Plan 028 follow-ups in the completed plan; updated requirements **NFR-5.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
